### PR TITLE
Update UploadableBehavior.php

### DIFF
--- a/src/Model/Behavior/UploadableBehavior.php
+++ b/src/Model/Behavior/UploadableBehavior.php
@@ -275,7 +275,7 @@ class UploadableBehavior extends Behavior
         foreach ($fieldConfig['fields'] as $key => $column) {
             if ($column) {
                 if ($key == "directory") {
-                    $entity->set($column, $this->_getPath($entity, $field, ['root' => false, 'file' => true]));
+                    $entity->set($column, $this->_getPath($entity, $field, ['root' => false, 'file' => false]));
                 }
                 if ($key == "type") {
                     $entity->set($column, $_upload['type']);


### PR DESCRIPTION
When the 'fileName' option was set to '{field}.{extension}', it was saving the file with the correct/expected name but was still putting the actual uploaded filename in the DB field. Fixed that.

Field config to re-produce the issue fixed:

```
    $this->addBehavior('Utils.Uploadable', [
        'photo'=> [
            'fields' => [
                'size' => 'photo_size',
                'type' => 'photo_type',
                'directory' => 'photo_path',
            ],
            'removeFileOnUpdate' => true,
            'removeFileOnDelete' => true,
            'path' => '{ROOT}/{WEBROOT}/uploads/{model}/',
            'field' => 'id',
            'fileName' => '{field}.{extension}',
        ],
    ]);
```
