### PR TITLE
Making link active base path fix

### DIFF
--- a/src/Controller/Component/MenuComponent.php
+++ b/src/Controller/Component/MenuComponent.php
@@ -231,7 +231,7 @@ class MenuComponent extends Component
         $url = Router::url($item['url']);
         $actives = $this->config('active');
 
-        if ($url === "/" . $this->Controller->request->url) {
+        if ($url === Router::url("/" . $this->Controller->request->url)) {
             $item['active'] = true;
         }
 


### PR DESCRIPTION
When you use 'example.com/cakephp' instead of 'example.com' the base is 'cakephp' and you need to use Router::url to make correct url with base in path.
