### PR TITLE
Adding beforeSubMenu and afterSubMenu

### DIFF
--- a/src/View/Helper/MenuBuilderInterface.php
+++ b/src/View/Helper/MenuBuilderInterface.php
@@ -50,6 +50,17 @@ interface MenuBuilderInterface
     public function beforeMenu($menu = [], $options = []);
 
     /**
+     * beforeSubMenu
+     *
+     * Method before the submenu has been build.
+     *
+     * @param array $submenu The submenu items.
+     * @param array $options Options.
+     * @return string
+     */
+    public function beforeSubMenu($submenu = [], $options = []);
+
+    /**
      * beforeItem
      *
      * Method before an item has been build.
@@ -125,4 +136,15 @@ interface MenuBuilderInterface
      * @return string
      */
     public function afterMenu($menu = [], $options = []);
+
+    /**
+     * afterSubMenu
+     *
+     * Method after the submenu has been build.
+     *
+     * @param array $submenu The submenu items.
+     * @param array $options Options.
+     * @return string
+     */
+    public function afterSubMenu($submenu = [], $options = []);
 }

--- a/src/View/Helper/MenuHelper.php
+++ b/src/View/Helper/MenuHelper.php
@@ -86,11 +86,13 @@ class MenuHelper extends Helper
             $html .= $builder->beforeItem($item);
             $html .= $builder->item($item);
             if ($item['children']) {
-                $html .= $builder->beforeSubItem($item);
+                $html .= $builder->beforeSubMenu($item);
                 foreach ($item['children'] as $subItem) {
+                    $html .= $builder->beforeSubItem($subItem);
                     $html .= $builder->subItem($subItem);
+                    $html .= $builder->afterSubItem($subItem);
                 }
-                $html .= $builder->afterSubItem($item);
+                $html .= $builder->afterSubMenu($item);
             }
             $html .= $builder->afterItem($item);
         }


### PR DESCRIPTION
I think your callbacks beforeSubItem and afterSubItem were used on wrong place and also beforeSubMenu and afterSubMenu callbacks are missing.

With this approach we can build menu with two levels (parent and children = item and subitem), but what can we do when children have another children. I think we should recursively call some "buildMenu" method which could build as many level as needed. What do you think?
