### PR TITLE
Entity field based replacements for fileNames and Paths. And accept type as null or 'image'.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 api/
 vendor/
 composer.lock
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ api/
 vendor/
 composer.lock
 build/
+*.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
+  - 7.0
 
 sudo: false
 
@@ -20,10 +19,10 @@ matrix:
   fast_finish: true
 
   include:
-  - php: 5.5
+  - php: 5.6
     env: PHPCS=1 DEFAULT=0
 
-  - php: 5.5
+  - php: 5.6
     env: COVERALLS=1 DEFAULT=0 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
 
 install:

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": ">=5.5.9",
         "cakephp/cakephp": "~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "*",
-        "nesbot/carbon": "~1.14"
+        "nesbot/carbon": "*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
+        "php": ">=5.6",
         "cakephp/cakephp": "~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "*",
-        "nesbot/carbon": "*"
+        "nesbot/carbon": ">=1.13.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "cakephp/cakephp": "~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "*"
+        "phpunit/phpunit": "*",
+        "nesbot/carbon": "~1.14"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -29,6 +29,20 @@
         </listener>
     </listeners>
 
+    <filter>
+      <whitelist processUncoveredFilesFromWhitelist="true">
+        <directory suffix=".php">./</directory>
+        <directory suffix=".ctp">./</directory>
+        <exclude>
+            <directory suffix=".php">./vendor/</directory>
+            <directory suffix=".ctp">./vendor/</directory>
+
+            <directory suffix=".php">./tests/</directory>
+            <directory suffix=".ctp">./tests/</directory>
+        </exclude>
+      </whitelist>
+    </filter>
+
     <!-- Prevent coverage reports from looking in tests and vendors -->
     <filter>
         <blacklist>
@@ -39,5 +53,4 @@
             <directory suffix=".ctp">./tests/</directory>
         </blacklist>
     </filter>
-
 </phpunit>

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -14,13 +14,13 @@
  */
 namespace Utils\Controller;
 
-use App\Controller\AppController as BaseController;
+use Cake\Controller\Controller;
 
 /**
  * AppController Class for Utils Plugin
  *
  */
-class AppController extends BaseController
+class AppController extends Controller
 {
 
 }

--- a/src/Model/Behavior/UploadableBehavior.php
+++ b/src/Model/Behavior/UploadableBehavior.php
@@ -125,7 +125,7 @@ class UploadableBehavior extends Behavior
                     $fieldConfig = $this->config($field);
 
                     if ($fieldConfig['removeFileOnUpdate']) {
-                        $this->_removeFile($entity->getOriginal($field));
+                        $this->_removeFile($entity, $field);
                     }
                 }
             }
@@ -177,16 +177,7 @@ class UploadableBehavior extends Behavior
         foreach ($fields as $field => $data) {
             $fieldConfig = $this->config($field);
             if ($fieldConfig['removeFileOnDelete']) {
-                $file = $entity->get($field);
-
-                if (empty($file)) {
-                    $fieldConfig = $this->config($field);
-                    $file = $entity->get($fieldConfig['fields']['filePath']);
-                }
-
-                if (!empty($file)) {
-                    $this->_removeFile($file);
-                }
+                $this->_removeFile($entity, $field);
             }
         }
     }
@@ -530,11 +521,19 @@ class UploadableBehavior extends Behavior
     /**
      * _removeFile
      *
-     * @param string $file Path of the file
+     * @param \Cake\ORM\Entity $entity Entity to check on.
+     * @param string $field Field to check on.
      * @return bool
      */
-    protected function _removeFile($file)
+    protected function _removeFile($entity, $field)
     {
+        $file = $entity->getOriginal($field);
+
+        if (is_null($file)) {
+            $fieldConfig = $this->config($field);
+            $file = $entity->getOriginal($fieldConfig['fields']['filePath']);
+        }
+
         $_file = new File($file);
 
         if ($_file->exists()) {

--- a/src/Model/Behavior/UploadableBehavior.php
+++ b/src/Model/Behavior/UploadableBehavior.php
@@ -257,7 +257,7 @@ class UploadableBehavior extends Behavior
 
         $fieldConfig = $this->config($field);
 
-        if ($fieldConfig['accept_type'] === 'image' && !$this->_IsImage($_upload)) {
+        if ($fieldConfig['accept_type'] === 'image' && !$this->_isImage($_upload)) {
             return false;
         }
 
@@ -421,7 +421,8 @@ class UploadableBehavior extends Behavior
 
     /**
      * _setEntityReplacements method
-     * @param array $entity Entity
+     * @param \Cake\ORM\Entity $entity Entity to check on.
+     * @param string $field Field to check on.
      * @param array $replacements List of current replacements
      * @return array
      */
@@ -543,14 +544,13 @@ class UploadableBehavior extends Behavior
     }
 
     /**
-     * _IsImage
+     * _isImage
      *
      * @param string $data array data of file
      * @return bool
      */
-    public function _IsImage($data)
+    protected function _isImage($data)
     {
-
         $fileMimeType = exif_imagetype($data['tmp_name']);
         $filename = strtolower($data['name']);
         $fileNameArray = explode('.', $filename);

--- a/src/Model/Behavior/UploadableBehavior.php
+++ b/src/Model/Behavior/UploadableBehavior.php
@@ -48,7 +48,7 @@ class UploadableBehavior extends Behavior
             'removeFileOnUpdate' => true,
             'removeFileOnDelete' => true,
             'field' => 'id',
-            'path' => '{ROOT}{DS}{WEBROOT}{DS}uploads{DS}{model}{DS}{field}{DS}',
+            'path' => '{ROOT}{WEBROOT}{DS}uploads{DS}{model}{DS}{field}{DS}',
             'fileName' => '{ORIGINAL}',
             'entityReplacements' => [ ],
             'accept_type' => null /* can be 'image'*/
@@ -452,7 +452,7 @@ class UploadableBehavior extends Behavior
     protected function _getUrl($entity, $field)
     {
         $path = '/' . $this->_getPath($entity, $field, ['root' => false, 'file' => true]);
-        return str_replace(DS, '/', $path);
+        return str_replace(DS, '/', str_replace('//', '/', $path));
     }
 
     /**

--- a/src/Model/Behavior/UploadableBehavior.php
+++ b/src/Model/Behavior/UploadableBehavior.php
@@ -269,10 +269,7 @@ class UploadableBehavior extends Behavior
         }
 
         // upload the file and return true
-        if ($this->_moveUploadedFile($_upload['tmp_name'], $uploadPath)) {
-            return true;
-        }
-        return false;
+        return $this->_moveUploadedFile($_upload['tmp_name'], $uploadPath) ? true : false;
     }
 
     /**

--- a/src/Model/Behavior/UploadableBehavior.php
+++ b/src/Model/Behavior/UploadableBehavior.php
@@ -177,7 +177,16 @@ class UploadableBehavior extends Behavior
         foreach ($fields as $field => $data) {
             $fieldConfig = $this->config($field);
             if ($fieldConfig['removeFileOnDelete']) {
-                $this->_removeFile($entity->get($field));
+                $file = $entity->get($field);
+
+                if (empty($file)) {
+                    $fieldConfig = $this->config($field);
+                    $file = $entity->get($fieldConfig['fields']['filePath']);
+                }
+
+                if (!empty($file)) {
+                    $this->_removeFile($file);
+                }
             }
         }
     }

--- a/src/Model/Behavior/UploadableBehavior.php
+++ b/src/Model/Behavior/UploadableBehavior.php
@@ -50,6 +50,7 @@ class UploadableBehavior extends Behavior
             'field' => 'id',
             'path' => '{ROOT}{DS}{WEBROOT}{DS}uploads{DS}{model}{DS}{field}{DS}',
             'fileName' => '{ORIGINAL}',
+            'entityReplacements' => [],
         ]
     ];
 
@@ -114,7 +115,7 @@ class UploadableBehavior extends Behavior
                 $uploads[$field] = $entity->get($field);
                 $entity->set($field, null);
             }
-
+            
             if (!$entity->isNew()) {
                 $dirtyField = $entity->dirty($field);
                 $originalField = $entity->getOriginal($field);
@@ -394,6 +395,8 @@ class UploadableBehavior extends Behavior
             '\\' => DIRECTORY_SEPARATOR,
         ];
 
+        $replacements = $this->_setEntityReplacements($entity, $field, $replacements);
+
         $builtPath = str_replace(array_keys($replacements), array_values($replacements), $path);
 
         if (!$options['root']) {
@@ -405,6 +408,20 @@ class UploadableBehavior extends Behavior
         }
 
         return $builtPath;
+    }
+
+    /**
+     * _setEntityReplacements method
+     * @param array $entity Entity
+     * @param array $replacements List of current replacements
+     * @return array
+     */
+    protected function _setEntityReplacements($entity, $field, array $replacements)
+    {
+        foreach ($this->config($field . '.entityReplacements') as $key => $field) {
+            $replacements[$key] = $entity->get($field);
+        }
+        return $replacements;
     }
 
     /**
@@ -457,6 +474,8 @@ class UploadableBehavior extends Behavior
             '/' => DIRECTORY_SEPARATOR,
             '\\' => DIRECTORY_SEPARATOR,
         ];
+        
+        $replacements = $this->_setEntityReplacements($entity, $field, $replacements);
 
         $builtFileName = str_replace(array_keys($replacements), array_values($replacements), $fileName);
 

--- a/tests/TestCase/Model/Behavior/UploadableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UploadableBehaviorTest.php
@@ -70,10 +70,12 @@ class UploadableBehaviorTest extends TestCase
     /**
      * delTree method
      *
+     * @param string $dir of directory
      * @return bool
      */
-    private static function delTree($dir) {
-        $files = array_diff(scandir($dir), array('.','..'));
+    protected static function _delTree($dir)
+    {
+        $files = array_diff(scandir($dir), [ '.', '..' ]);
         foreach ($files as $file) {
             (is_dir("$dir/$file")) ? self::delTree("$dir/$file") : unlink("$dir/$file");
         }
@@ -292,7 +294,7 @@ class UploadableBehaviorTest extends TestCase
 
         $table->behaviors()->set('Uploadable', $behaviorMock);
 
-        $tmp_name = ROOT . 'README.md';
+        $tmpName = ROOT . 'README.md';
         $data = [
             'id' => 3,
             'user_id' => 5,
@@ -301,7 +303,7 @@ class UploadableBehaviorTest extends TestCase
             'file' => [
                 'name' => 'README.md',
                 'type' => 'text/x-markdown',
-                'tmp_name' => $tmp_name,
+                'tmp_name' => $tmpName,
                 'error' => 0,
                 'size' => 11501
             ]
@@ -312,7 +314,7 @@ class UploadableBehaviorTest extends TestCase
 
         $get = $table->get(3);
 
-        copy($tmp_name, $this->_uploadPath . DS . 'articles' . DS . '3' . DS . 'README.md');
+        copy($tmpName, $this->_uploadPath . DS . 'articles' . DS . '3' . DS . 'README.md');
 
         $this->assertTrue(file_exists($this->_uploadPath . DS . 'articles' . DS . '3' . DS . 'README.md'));
         $this->assertContains('/uploads/articles/3/README.md', $get->get('url'));
@@ -334,7 +336,7 @@ class UploadableBehaviorTest extends TestCase
             'file' => [
                 'name' => 'README2.md',
                 'type' => 'text/x-markdown',
-                'tmp_name' => $tmp_name,
+                'tmp_name' => $tmpName,
                 'error' => 0,
                 'size' => 11501
             ]
@@ -388,7 +390,7 @@ class UploadableBehaviorTest extends TestCase
 
         $table->behaviors()->set('Uploadable', $behaviorMock);
 
-        $tmp_name = ROOT . 'README.md';
+        $tmpName = ROOT . 'README.md';
         $data = [
             'id' => 3,
             'user_id' => 5,
@@ -397,7 +399,7 @@ class UploadableBehaviorTest extends TestCase
             'file' => [
                 'name' => 'README.md',
                 'type' => 'text/x-markdown',
-                'tmp_name' => $tmp_name,
+                'tmp_name' => $tmpName,
                 'error' => 0,
                 'size' => 11501
             ]
@@ -408,7 +410,7 @@ class UploadableBehaviorTest extends TestCase
 
         $get = $table->get(3);
 
-        copy($tmp_name, $this->_uploadPath . DS . 'articles' . DS . '3' . DS . 'README.md');
+        copy($tmpName, $this->_uploadPath . DS . 'articles' . DS . '3' . DS . 'README.md');
 
         $this->assertTrue(file_exists($this->_uploadPath . DS . 'articles' . DS . '3' . DS . 'README.md'));
         $this->assertContains('/uploads/articles/3/README.md', $get->get('url'));

--- a/tests/TestCase/Model/Behavior/UploadableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UploadableBehaviorTest.php
@@ -61,7 +61,7 @@ class UploadableBehaviorTest extends TestCase
          * if created uploads by _mkdir, delete tree
          */
         if (is_dir($this->_uploadPath)) {
-            self::delTree($this->_uploadPath);
+            self::_delTree($this->_uploadPath);
         }
 
         parent::tearDown();
@@ -77,7 +77,7 @@ class UploadableBehaviorTest extends TestCase
     {
         $files = array_diff(scandir($dir), [ '.', '..' ]);
         foreach ($files as $file) {
-            (is_dir("$dir/$file")) ? self::delTree("$dir/$file") : unlink("$dir/$file");
+            (is_dir("$dir/$file")) ? self::_delTree("$dir/$file") : unlink("$dir/$file");
         }
         return rmdir($dir);
     }

--- a/tests/TestCase/Model/Behavior/UploadableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UploadableBehaviorTest.php
@@ -44,6 +44,8 @@ class UploadableBehaviorTest extends TestCase
         $this->Articles = $this->getMock('Cake\ORM\Table', ['_mkdir', '_moveUploadedFile'], [
             ['table' => 'articles', 'connection' => $connection]
         ]);
+
+        $this->_uploadPath = ROOT . 'webroot' . DS . 'uploads';
     }
 
     /**
@@ -55,7 +57,27 @@ class UploadableBehaviorTest extends TestCase
     {
         unset($this->Articles);
 
+        /*
+         * if created uploads by _mkdir, delete tree
+         */
+        if (is_dir($this->_uploadPath)) {
+            self::delTree($this->_uploadPath);
+        }
+
         parent::tearDown();
+    }
+
+    /**
+     * delTree method
+     *
+     * @return bool
+     */
+    private static function delTree($dir) {
+        $files = array_diff(scandir($dir), array('.','..'));
+        foreach ($files as $file) {
+            (is_dir("$dir/$file")) ? self::delTree("$dir/$file") : unlink("$dir/$file");
+        }
+        return rmdir($dir);
     }
 
     /**
@@ -80,7 +102,7 @@ class UploadableBehaviorTest extends TestCase
             ],
             'fieldWithCustomSettings2' => [
                 'field' => 'user_id',
-                'path' => '{ROOT}{DS}{WEBROOT}{DS}uploads{DS}{model}{DS}',
+                'path' => '{ROOT}{WEBROOT}{DS}uploads{DS}{model}{DS}',
                 'fileName' => '{field}.{extension}',
             ],
         ]);
@@ -96,7 +118,7 @@ class UploadableBehaviorTest extends TestCase
         $this->assertTrue($action['fieldWithoutSettings']['removeFileOnUpdate']);
         $this->assertTrue($action['fieldWithoutSettings']['removeFileOnDelete']);
         $this->assertEquals("id", $action['fieldWithoutSettings']['field']);
-        $this->assertEquals("{ROOT}{DS}{WEBROOT}{DS}uploads{DS}{model}{DS}{field}{DS}", $action['fieldWithoutSettings']['path']);
+        $this->assertEquals("{ROOT}{WEBROOT}{DS}uploads{DS}{model}{DS}{field}{DS}", $action['fieldWithoutSettings']['path']);
         $this->assertEquals("{ORIGINAL}", $action['fieldWithoutSettings']['fileName']);
 
         // testing field 2
@@ -109,7 +131,7 @@ class UploadableBehaviorTest extends TestCase
 
         // testing field 3
         $this->assertEquals("user_id", $action['fieldWithCustomSettings2']['field']);
-        $this->assertEquals("{ROOT}{DS}{WEBROOT}{DS}uploads{DS}{model}{DS}", $action['fieldWithCustomSettings2']['path']);
+        $this->assertEquals("{ROOT}{WEBROOT}{DS}uploads{DS}{model}{DS}", $action['fieldWithCustomSettings2']['path']);
         $this->assertEquals("{field}.{extension}", $action['fieldWithCustomSettings2']['fileName']);
     }
 
@@ -186,26 +208,27 @@ class UploadableBehaviorTest extends TestCase
                     'type' => 'type',
                     'size' => 'size',
                 ],
+                'fileName' => '{primaryKey}_article_{userId}.{extension}',
+                'entityReplacements' => [
+                    '{primaryKey}' => 'id',
+                    '{userId}' => 'user_id'
+                ],
             ]
         ];
 
-        $mocks = ['_mkdir', '_MoveUploadedFile'];
+        $mocks = [ '_moveUploadedFile' ];
 
         $behaviorMock = $this->getMock('\Utils\Model\Behavior\UploadableBehavior', $mocks, [$table, $behaviorOptions]);
 
         $behaviorMock->expects($this->any())
-            ->method('_mkdir')
-            ->will($this->returnValue(true));
-        $behaviorMock->expects($this->any())
-            ->method('_MoveUploadedFile')
+            ->method('_moveUploadedFile')
             ->will($this->returnValue(true));
 
         $table->behaviors()->set('Uploadable', $behaviorMock);
 
-
         $data = [
             'id' => 3,
-            'user_id' => 3,
+            'user_id' => 5,
             'title' => 'My first article',
             'body' => 'Content',
             'file' => [
@@ -222,11 +245,238 @@ class UploadableBehaviorTest extends TestCase
 
         $get = $table->get(3);
 
-        $this->assertContains('/uploads/articles/3/cakemanager.png', $get->get('url'));
+        $this->assertContains('/uploads/articles/3/3_article_5.png', $get->get('url'));
         $this->assertContains('uploads' . DS . 'articles' . DS . '3' . DS, $get->get('directory'));
         $this->assertEquals("image/png", $get->get('type'));
         $this->assertEquals(11501, $get->get('size'));
-        $this->assertContains('cakemanager.png', $get->get('file_name'));
-        $this->assertContains('uploads' . DS . 'articles' . DS . '3' . DS . 'cakemanager.png', $get->get('file_path'));
+        $this->assertContains('3_article_5.png', $get->get('file_name'));
+        $this->assertContains('uploads' . DS . 'articles' . DS . '3' . DS . '3_article_5.png', $get->get('file_path'));
+    }
+
+    /**
+     * testRemoveFileOnUpdate
+     *
+     * @return void
+     */
+    public function testRemoveFileOnUpdate()
+    {
+        $connection = ConnectionManager::get('test');
+
+        $table = $this->getMock('Cake\ORM\Table', ['_nonExistingMethodElseTheMockWillMockAllMethods'], [
+            ['table' => 'articles', 'connection' => $connection]
+        ]);
+
+        $table->alias("Articles");
+
+        $behaviorOptions = [
+            'file' => [
+                'fields' => [
+                    'url' => 'url',
+                    'directory' => 'directory',
+                    'fileName' => 'file_name',
+                    'filePath' => 'file_path',
+                    'type' => 'type',
+                    'size' => 'size',
+                ],
+                'removeFileOnUpdate' => true
+            ]
+        ];
+
+        $mocks = [ '_moveUploadedFile' ];
+
+        $behaviorMock = $this->getMock('\Utils\Model\Behavior\UploadableBehavior', $mocks, [$table, $behaviorOptions]);
+
+        $behaviorMock->expects($this->any())
+            ->method('_moveUploadedFile')
+            ->will($this->returnValue(true));
+
+        $table->behaviors()->set('Uploadable', $behaviorMock);
+
+        $tmp_name = ROOT . 'README.md';
+        $data = [
+            'id' => 3,
+            'user_id' => 5,
+            'title' => 'My first article',
+            'body' => 'Content',
+            'file' => [
+                'name' => 'README.md',
+                'type' => 'text/x-markdown',
+                'tmp_name' => $tmp_name,
+                'error' => 0,
+                'size' => 11501
+            ]
+        ];
+
+        $entity = $table->newEntity($data);
+        $save = $table->save($entity);
+
+        $get = $table->get(3);
+
+        copy($tmp_name, $this->_uploadPath . DS . 'articles' . DS . '3' . DS . 'README.md');
+
+        $this->assertTrue(file_exists($this->_uploadPath . DS . 'articles' . DS . '3' . DS . 'README.md'));
+        $this->assertContains('/uploads/articles/3/README.md', $get->get('url'));
+        $this->assertContains('uploads' . DS . 'articles' . DS . '3' . DS, $get->get('directory'));
+        $this->assertContains('README.md', $get->get('file_name'));
+        $this->assertContains('uploads' . DS . 'articles' . DS . '3' . DS . 'README.md', $get->get('file_path'));
+
+        // $behaviorMock->expects($this->any())
+        //     ->method('_moveUploadedFile')
+        //     ->will($this->returnValue(false));
+
+        // $table->behaviors()->set('Uploadable', $behaviorMock);
+
+        $data = [
+            'id' => 3,
+            'user_id' => 5,
+            'title' => 'My first article',
+            'body' => 'Content',
+            'file' => [
+                'name' => 'README2.md',
+                'type' => 'text/x-markdown',
+                'tmp_name' => $tmp_name,
+                'error' => 0,
+                'size' => 11501
+            ]
+        ];
+        $entity = $table->newEntity($data);
+        $save = $table->save($entity);
+
+        $get = $table->get(3);
+        $this->assertFalse(file_exists('uploads' . DS . 'articles' . DS . '3' . DS . 'README.md'));
+        $this->assertContains('/uploads/articles/3/README2.md', $get->get('url'));
+        $this->assertContains('uploads' . DS . 'articles' . DS . '3' . DS, $get->get('directory'));
+        $this->assertContains('README2.md', $get->get('file_name'));
+        $this->assertContains('uploads' . DS . 'articles' . DS . '3' . DS . 'README2.md', $get->get('file_path'));
+    }
+
+    /**
+     * testRemoveFileOnDelete
+     *
+     * @return void
+     */
+    public function testRemoveFileOnDelete()
+    {
+        $connection = ConnectionManager::get('test');
+
+        $table = $this->getMock('Cake\ORM\Table', ['_nonExistingMethodElseTheMockWillMockAllMethods'], [
+            ['table' => 'articles', 'connection' => $connection]
+        ]);
+
+        $table->alias("Articles");
+
+        $behaviorOptions = [
+            'file' => [
+                'fields' => [
+                    'url' => 'url',
+                    'directory' => 'directory',
+                    'fileName' => 'file_name',
+                    'filePath' => 'file_path',
+                    'type' => 'type',
+                    'size' => 'size',
+                ],
+            ]
+        ];
+
+        $mocks = [ '_moveUploadedFile' ];
+
+        $behaviorMock = $this->getMock('\Utils\Model\Behavior\UploadableBehavior', $mocks, [$table, $behaviorOptions]);
+
+        $behaviorMock->expects($this->any())
+            ->method('_moveUploadedFile')
+            ->will($this->returnValue(true));
+
+        $table->behaviors()->set('Uploadable', $behaviorMock);
+
+        $tmp_name = ROOT . 'README.md';
+        $data = [
+            'id' => 3,
+            'user_id' => 5,
+            'title' => 'My first article',
+            'body' => 'Content',
+            'file' => [
+                'name' => 'README.md',
+                'type' => 'text/x-markdown',
+                'tmp_name' => $tmp_name,
+                'error' => 0,
+                'size' => 11501
+            ]
+        ];
+
+        $entity = $table->newEntity($data);
+        $save = $table->save($entity);
+
+        $get = $table->get(3);
+
+        copy($tmp_name, $this->_uploadPath . DS . 'articles' . DS . '3' . DS . 'README.md');
+
+        $this->assertTrue(file_exists($this->_uploadPath . DS . 'articles' . DS . '3' . DS . 'README.md'));
+        $this->assertContains('/uploads/articles/3/README.md', $get->get('url'));
+        $this->assertContains('uploads' . DS . 'articles' . DS . '3' . DS, $get->get('directory'));
+        $this->assertContains('README.md', $get->get('file_name'));
+        // $this->assertContains('uploads' . DS . 'articles' . DS . '3' . DS . 'README.md', $get->get('file_path'));
+
+        $table->delete($get);
+        $this->assertFalse(file_exists($this->_uploadPath . DS . 'articles' . DS . '3' . DS . 'README.md'));
+    }
+
+    /**
+     * testSaveWithWrongType
+     *
+     * @return void
+     */
+    public function testSaveWithWrongType()
+    {
+        $connection = ConnectionManager::get('test');
+
+        $table = $this->getMock('Cake\ORM\Table', ['_nonExistingMethodElseTheMockWillMockAllMethods'], [
+            ['table' => 'articles', 'connection' => $connection]
+        ]);
+
+        $table->alias("Articles");
+
+        $behaviorOptions = [
+            'file' => [
+                'fields' => [
+                    'url' => 'url',
+                    'directory' => 'directory',
+                    'fileName' => 'file_name',
+                    'filePath' => 'file_path',
+                    'type' => 'type',
+                    'size' => 'size',
+                ],
+                'accept_type' => 'image'
+            ]
+        ];
+
+        $behaviorMock = $this->getMock('\Utils\Model\Behavior\UploadableBehavior', null, [$table, $behaviorOptions]);
+
+        $table->behaviors()->set('Uploadable', $behaviorMock);
+
+        $data = [
+            'id' => 3,
+            'user_id' => 3,
+            'title' => 'My first article',
+            'body' => 'Content',
+            'file' => [
+                'name' => 'README.md',
+                'type' => 'text/x-markdown',
+                'tmp_name' => ROOT . 'README.md',
+                'error' => 0,
+                'size' => 11501
+            ]
+        ];
+
+        $entity = $table->newEntity($data);
+        $save = $table->save($entity);
+
+        $get = $table->get(3);
+
+        $this->assertEmpty($get->get('url'));
+        $this->assertEmpty($get->get('type'));
+        $this->assertEmpty($get->get('size'));
+        $this->assertEmpty($get->get('file_name'));
+        $this->assertEmpty($get->get('file_path'));
+        $this->assertFalse(file_exists($this->_uploadPath . DS . 'articles' . DS . '3' . DS . 'README.md'));
     }
 }


### PR DESCRIPTION
- Users can set entity field based replacements for fileNames and Paths
- Users can set the accept type as null or 'image'.

``` php
        $this->addBehavior('User.Uploadable', [
            'avatar_path' => [
                'field' => 'avatar_path',
                'path' => '{ROOT}{DS}{WEBROOT}{DS}uploads{DS}{model}{DS}avatar{DS}{primaryKey}{DS}',
                'fileName' => '{primaryKey}_avatar_' . $now . '.{extension}',
                'entityReplacements' => [
                    '{primaryKey}' => 'id',
                ],
                'accept_type' => 'image'
            ],
        ]);
```
