### PR TITLE
Fix deprecation errors on CakePHP 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
 
 sudo: false
@@ -20,10 +18,10 @@ matrix:
   fast_finish: true
 
   include:
-  - php: 5.5
+  - php: 5.6
     env: PHPCS=1 DEFAULT=0
 
-  - php: 5.5
+  - php: 5.6
     env: COVERALLS=1 DEFAULT=0 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
 
 install:
@@ -34,17 +32,17 @@ before_script:
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi"
   - sh -c "if [ '$PHPCS' = '1' ]; then composer require cakephp/cakephp-codesniffer:dev-master; fi"
-  - sh -c "if [ '$COVERALLS' = '1' ]; then composer require --dev satooshi/php-coveralls:dev-master; fi"
+  - sh -c "if [ '$COVERALLS' = '1' ]; then composer require --dev php-coveralls/php-coveralls; fi"
   - sh -c "if [ '$COVERALLS' = '1' ]; then mkdir -p build/logs; fi"
 
   - phpenv rehash
   - set +H
 
 script:
-  - sh -c "if [ '$DEFAULT' = '1' ]; then phpunit --stderr; fi"
+  - sh -c "if [ '$DEFAULT' = '1' ]; then vendor/bin/phpunit; fi"
   - sh -c "if [ '$PHPCS' = '1' ]; then ./vendor/bin/phpcs -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi"
-  - sh -c "if [ '$COVERALLS' = '1' ]; then phpunit --stderr --coverage-clover build/logs/clover.xml; fi"
-  - sh -c "if [ '$COVERALLS' = '1' ]; then php vendor/bin/coveralls -c .coveralls.yml -v; fi"
+  - sh -c "if [ '$COVERALLS' = '1' ]; then ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml; fi"
+  - sh -c "if [ '$COVERALLS' = '1' ]; then php vendor/bin/php-coveralls -c .coveralls.yml -v; fi"
 
 notifications:
   email: false

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,12 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
-        "cakephp/cakephp": "~3.0"
+        "php": ">=5.6.0",
+        "cakephp/cakephp": "~3.0",
+        "cakephp/cakephp-codesniffer": "dev-master"
     },
     "require-dev": {
-        "phpunit/phpunit": "*"
+        "phpunit/phpunit": "^5.7.14|^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -29,8 +29,11 @@
         </listener>
     </listeners>
 
-    <!-- Prevent coverage reports from looking in tests and vendors -->
     <filter>
+        <whitelist>
+            <directory suffix=".php">./src/</directory>
+        </whitelist>
+        <!-- Prevent coverage reports from looking in tests and vendors -->
         <blacklist>
             <directory suffix=".php">./vendor/</directory>
             <directory suffix=".ctp">./vendor/</directory>

--- a/src/Controller/Component/AuthorizerComponent.php
+++ b/src/Controller/Component/AuthorizerComponent.php
@@ -94,7 +94,7 @@ class AuthorizerComponent extends Component
      */
     public function beforeFilter($event)
     {
-        $this->setController($event->subject());
+        $this->setController($event->getSubject());
 
         $this->setCurrentParams();
     }
@@ -108,9 +108,9 @@ class AuthorizerComponent extends Component
      */
     public function setCurrentParams()
     {
-        $this->_current['plugin'] = $this->Controller->request->params['plugin'];
-        $this->_current['controller'] = $this->Controller->request->params['controller'];
-        $this->_current['action'] = $this->Controller->request->params['action'];
+        $this->_current['plugin'] = $this->Controller->request->getParam('plugin');
+        $this->_current['controller'] = $this->Controller->request->getParam('controller');
+        $this->_current['action'] = $this->Controller->request->getParam('action');
 
         return $this->_current;
     }
@@ -147,7 +147,6 @@ class AuthorizerComponent extends Component
         if (!is_array($actions)) {
             $actions = [$actions];
         }
-
 
         $controller = $this->_current['controller'];
 
@@ -285,7 +284,7 @@ class AuthorizerComponent extends Component
     public function authorize()
     {
         $user = $this->Controller->Auth->user();
-        $role = $user[$this->config('roleField')];
+        $role = $user[$this->getConfig('roleField')];
 
         $controller = $this->_current['controller'];
         $action = $this->_current['action'];
@@ -347,7 +346,6 @@ class AuthorizerComponent extends Component
         if (!is_bool($state)) {
             $state = false;
         }
-
 
         return $state;
     }

--- a/src/Controller/Component/MenuComponent.php
+++ b/src/Controller/Component/MenuComponent.php
@@ -110,7 +110,7 @@ class MenuComponent extends Component
      */
     public function beforeFilter($event)
     {
-        $this->setController($event->subject());
+        $this->setController($event->getSubject());
 
         if (method_exists($this->Controller, 'initMenuItems')) {
             $this->Controller->initMenuItems($event);
@@ -134,6 +134,7 @@ class MenuComponent extends Component
         if ($area !== null) {
             $this->area = $area;
         }
+
         return $this->area;
     }
 
@@ -229,9 +230,8 @@ class MenuComponent extends Component
         $item = array_merge($_item, $item);
 
         $url = Router::url($item['url']);
-        $actives = $this->config('active');
-
-        if ($url === Router::url("/" . $this->Controller->request->url)) {
+        $actives = $this->getConfig('active');
+        if ($url === Router::url("/" . $this->Controller->request->getPath())) {
             $item['active'] = true;
         }
 

--- a/src/Controller/Component/SearchComponent.php
+++ b/src/Controller/Component/SearchComponent.php
@@ -85,7 +85,7 @@ class SearchComponent extends Component
      */
     public function beforeRender($event)
     {
-        $this->Controller->set('searchFilters', $this->_normalize($this->config('filters')));
+        $this->Controller->set('searchFilters', $this->_normalize($this->getConfig('filters')));
     }
 
     /**
@@ -106,14 +106,14 @@ class SearchComponent extends Component
      */
     public function addFilter($name, $options = [])
     {
-        $_options = $this->config('_default');
+        $_options = $this->getConfig('_default');
 
         $_options['field'] = $name;
         $_options['column'] = $name;
 
         $options = array_merge($_options, $options);
 
-        $this->config('filters.' . $name, $options, true);
+        $this->setConfig('filters.' . $name, $options, true);
     }
 
     /**
@@ -126,10 +126,10 @@ class SearchComponent extends Component
      */
     public function removeFilter($name)
     {
-        $filters = $this->config('filters');
+        $filters = $this->getConfig('filters');
         unset($filters[$name]);
 
-        $this->config('filters', $filters, false);
+        $this->setConfig('filters', $filters, false);
     }
 
     /**
@@ -154,11 +154,11 @@ class SearchComponent extends Component
      */
     public function search(\Cake\ORM\Query $query, $options = [])
     {
-        $_query = $this->Controller->request->query;
-        $this->Controller->request->data = $_query;
+        $_query = $this->Controller->request->getQuery();
+        $this->Controller->request->withData('', $_query);
 
         $params = $_query;
-        $filters = $this->_normalize($this->config('filters'));
+        $filters = $this->_normalize($this->getConfig('filters'));
 
         foreach ($filters as $field => $options) {
             $hash = Hash::get($params, $options['column']);
@@ -193,6 +193,7 @@ class SearchComponent extends Component
         if ($options['operator'] === 'LIKE') {
             $string .= ' LIKE';
         }
+
         return $string;
     }
 
@@ -217,6 +218,7 @@ class SearchComponent extends Component
         if ($options['operator'] === 'LIKE') {
             $string .= '%';
         }
+
         return $string;
     }
 
@@ -235,7 +237,7 @@ class SearchComponent extends Component
         $key = 'filters.' . $field . '.attributes.value';
         $value = Hash::get($params, $options['column']);
 
-        $this->config($key, $value);
+        $this->setConfig($key, $value);
     }
 
     /**

--- a/src/Model/Behavior/IsOwnedByBehavior.php
+++ b/src/Model/Behavior/IsOwnedByBehavior.php
@@ -53,7 +53,7 @@ class IsOwnedByBehavior extends Behavior
             return false;
         }
 
-        $itemUserId = $item[$this->config('column')];
+        $itemUserId = $item[$this->getConfig('column')];
         $userId = $user['id'];
 
         if ($itemUserId === $userId) {

--- a/src/Model/Behavior/StateableBehavior.php
+++ b/src/Model/Behavior/StateableBehavior.php
@@ -50,7 +50,7 @@ class StateableBehavior extends Behavior
      */
     public function stateList()
     {
-        return array_flip($this->config('states'));
+        return array_flip($this->getConfig('states'));
     }
 
     /**
@@ -65,7 +65,7 @@ class StateableBehavior extends Behavior
     public function findConcept($query, $options)
     {
         $query->where([
-            $this->config('field') => $this->config('states.concept'),
+            $this->getConfig('field') => $this->getConfig('states.concept'),
         ]);
 
         return $query;
@@ -83,7 +83,7 @@ class StateableBehavior extends Behavior
     public function findActive($query, $options)
     {
         $query->where([
-            $this->config('field') => $this->config('states.active'),
+            $this->getConfig('field') => $this->getConfig('states.active'),
         ]);
 
         return $query;
@@ -101,7 +101,7 @@ class StateableBehavior extends Behavior
     public function findDeleted($query, $options)
     {
         $query->where([
-            $this->config('field') => $this->config('states.deleted'),
+            $this->getConfig('field') => $this->getConfig('states.deleted'),
         ]);
 
         return $query;

--- a/src/Model/Behavior/UploadableBehavior.php
+++ b/src/Model/Behavior/UploadableBehavior.php
@@ -88,11 +88,11 @@ class UploadableBehavior extends Behavior
 
         Type::map('Utils.File', 'Utils\Database\Type\FileType');
 
-        $schema = $table->schema();
+        $schema = $table->getSchema();
         foreach ($this->getFieldList() as $field => $settings) {
-            $schema->columnType($field, 'Utils.File');
+            $schema->setColumnType($field, 'Utils.File');
         }
-        $table->schema($schema);
+        $table->setSchema($schema);
 
         $this->_Table = $table;
     }
@@ -116,10 +116,10 @@ class UploadableBehavior extends Behavior
             }
 
             if (!$entity->isNew()) {
-                $dirtyField = $entity->dirty($field);
+                $dirtyField = $entity->setDirty($field);
                 $originalField = $entity->getOriginal($field);
                 if ($dirtyField && !is_null($originalField) && !is_array($originalField)) {
-                    $fieldConfig = $this->config($field);
+                    $fieldConfig = $this->getConfig($field);
 
                     if ($fieldConfig['removeFileOnUpdate']) {
                         $this->_removeFile($entity->getOriginal($field));
@@ -153,7 +153,7 @@ class UploadableBehavior extends Behavior
             }
         }
         foreach ($storedToSave as $toSave) {
-            $event->subject()->save($toSave);
+            $event->getSubject()->save($toSave);
         }
         $this->_savedFields = [];
     }
@@ -170,7 +170,7 @@ class UploadableBehavior extends Behavior
     {
         $fields = $this->getFieldList();
         foreach ($fields as $field => $data) {
-            $fieldConfig = $this->config($field);
+            $fieldConfig = $this->getConfig($field);
             if ($fieldConfig['removeFileOnDelete']) {
                 $this->_removeFile($entity->get($field));
             }
@@ -196,7 +196,7 @@ class UploadableBehavior extends Behavior
 
         $list = [];
 
-        foreach ($this->config() as $key => $value) {
+        foreach ($this->getConfig() as $key => $value) {
             if (!in_array($key, $this->_presetConfigKeys) || is_integer($key)) {
                 if (is_integer($key)) {
                     $field = $value;
@@ -207,12 +207,13 @@ class UploadableBehavior extends Behavior
                 if ($options['normalize']) {
                     $fieldConfig = $this->_normalizeField($field);
                 } else {
-                    $fieldConfig = (($this->config($field) == null) ? [] : $this->config($field));
+                    $fieldConfig = (($this->getConfig($field) == null) ? [] : $this->getConfig($field));
                 }
 
                 $list[$field] = $fieldConfig;
             }
         }
+
         return $list;
     }
 
@@ -234,6 +235,7 @@ class UploadableBehavior extends Behavior
                 return true;
             }
         }
+
         return false;
     }
 
@@ -261,6 +263,7 @@ class UploadableBehavior extends Behavior
         if ($this->_moveUploadedFile($_upload['tmp_name'], $uploadPath)) {
             return true;
         }
+
         return false;
     }
 
@@ -278,7 +281,7 @@ class UploadableBehavior extends Behavior
      */
     protected function _setUploadColumns($entity, $field, $options = [])
     {
-        $fieldConfig = $this->config($field);
+        $fieldConfig = $this->getConfig($field);
         $_upload = $this->_uploads[$field];
 
         // set all columns with values
@@ -304,6 +307,7 @@ class UploadableBehavior extends Behavior
                 }
             }
         }
+
         return $entity;
     }
 
@@ -328,13 +332,13 @@ class UploadableBehavior extends Behavior
 
         $options = Hash::merge($_options, $options);
 
-        $data = $this->config($field);
+        $data = $this->getConfig($field);
 
         if (is_null($data)) {
-            foreach ($this->config() as $key => $config) {
+            foreach ($this->getConfig() as $key => $config) {
                 if ($config == $field) {
                     if ($options['save']) {
-                        $this->config($field, []);
+                        $this->setConfig($field, []);
 
                         $this->_configDelete($key);
                     }
@@ -349,10 +353,10 @@ class UploadableBehavior extends Behavior
             $data = Hash::insert($data, 'fields.filePath', $field);
         }
 
-        $data = Hash::merge($this->config('defaultFieldConfig'), $data);
+        $data = Hash::merge($this->getConfig('defaultFieldConfig'), $data);
 
         if ($options['save']) {
-            $this->config($field, $data);
+            $this->setConfig($field, $data);
         }
 
         return $data;
@@ -381,7 +385,7 @@ class UploadableBehavior extends Behavior
 
         $options = Hash::merge($_options, $options);
 
-        $config = $this->config($field);
+        $config = $this->getConfig($field);
 
         $path = $config['path'];
 
@@ -389,7 +393,7 @@ class UploadableBehavior extends Behavior
             '{ROOT}' => ROOT,
             '{WEBROOT}' => 'webroot',
             '{field}' => $entity->get($config['field']),
-            '{model}' => Inflector::underscore($this->_Table->alias()),
+            '{model}' => Inflector::underscore($this->_Table->getAlias()),
             '{DS}' => DIRECTORY_SEPARATOR,
             '\\' => DIRECTORY_SEPARATOR,
         ];
@@ -419,6 +423,7 @@ class UploadableBehavior extends Behavior
     protected function _getUrl($entity, $field)
     {
         $path = '/' . $this->_getPath($entity, $field, ['root' => false, 'file' => true]);
+
         return str_replace(DS, '/', $path);
     }
 
@@ -439,7 +444,7 @@ class UploadableBehavior extends Behavior
 
         $options = Hash::merge($_options, $options);
 
-        $config = $this->config($field);
+        $config = $this->getConfig($field);
 
         $_upload = $this->_uploads[$field];
 
@@ -509,8 +514,10 @@ class UploadableBehavior extends Behavior
             if (count($folder->find()) === 0) {
                 $folder->delete();
             }
+
             return true;
         }
+
         return false;
     }
 }

--- a/src/Model/Behavior/WhoDidItBehavior.php
+++ b/src/Model/Behavior/WhoDidItBehavior.php
@@ -66,19 +66,19 @@ class WhoDidItBehavior extends Behavior
 
         $this->Table = $table;
 
-        if ($this->config('created_by')) {
+        if ($this->getConfig('created_by')) {
             $this->Table->belongsTo('CreatedBy', [
-                'foreignKey' => $this->config('created_by'),
-                'className' => $this->config('userModel'),
-                'propertyName' => $this->config('createdByPropertyName')
+                'foreignKey' => $this->getConfig('created_by'),
+                'className' => $this->getConfig('userModel'),
+                'propertyName' => $this->getConfig('createdByPropertyName')
             ]);
         }
 
-        if ($this->config('modified_by')) {
+        if ($this->getConfig('modified_by')) {
             $this->Table->belongsTo('ModifiedBy', [
-                'foreignKey' => $this->config('modified_by'),
-                'className' => $this->config('userModel'),
-                'propertyName' => $this->config('modifiedByPropertyName')
+                'foreignKey' => $this->getConfig('modified_by'),
+                'className' => $this->getConfig('userModel'),
+                'propertyName' => $this->getConfig('modifiedByPropertyName')
             ]);
         }
     }
@@ -109,13 +109,13 @@ class WhoDidItBehavior extends Behavior
      */
     public function beforeFind($event, $query, $options, $primary)
     {
-        if ($this->config('contain')) {
-            if ($this->config('created_by')) {
-                $query->contain(['CreatedBy' => ['fields' => $this->config('fields')]]);
+        if ($this->getConfig('contain')) {
+            if ($this->getConfig('created_by')) {
+                $query->contain(['CreatedBy' => ['fields' => $this->getConfig('fields')]]);
             }
 
-            if ($this->config('modified_by')) {
-                $query->contain(['ModifiedBy' => ['fields' => $this->config('fields')]]);
+            if ($this->getConfig('modified_by')) {
+                $query->contain(['ModifiedBy' => ['fields' => $this->getConfig('fields')]]);
             }
         }
     }
@@ -136,13 +136,13 @@ class WhoDidItBehavior extends Behavior
         $id = $auth['id'];
 
         if ($entity->isNew()) {
-            if ($this->config('created_by')) {
-                $entity->set($this->config('created_by'), $id);
+            if ($this->getConfig('created_by')) {
+                $entity->set($this->getConfig('created_by'), $id);
             }
         }
 
-        if ($this->config('modified_by')) {
-            $entity->set($this->config('modified_by'), $id);
+        if ($this->getConfig('modified_by')) {
+            $entity->set($this->getConfig('modified_by'), $id);
         }
     }
 }

--- a/src/View/Helper/SearchHelper.php
+++ b/src/View/Helper/SearchHelper.php
@@ -63,7 +63,7 @@ class SearchHelper extends Helper
             if ($field['options']) {
                 $field['attributes']['options'] = $field['options'];
             }
-            $html .= $this->Form->input($field['column'], $field['attributes']);
+            $html .= $this->Form->control($field['column'], $field['attributes']);
             $html .= ' ';
         }
 

--- a/tests/TestCase/Controller/Component/AuthorizerComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthorizerComponentTest.php
@@ -15,8 +15,8 @@
 namespace Utils\Test\TestCase\Controller\Component;
 
 use Cake\Controller\ComponentRegistry;
-use Cake\Network\Request;
-use Cake\Network\Response;
+use Cake\Http\Response;
+use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
 use Utils\Controller\Component\AuthorizerComponent;
@@ -87,15 +87,17 @@ class AuthorizerComponentTest extends TestCase
         $this->assertEquals("index", $set['action']);
 
         // Setup our component and fake test controller
-        $request = new Request(['params' => [
+        $request = new ServerRequest(['params' => [
                 'plugin' => 'utils',
                 'controller' => 'bookmarks',
                 'action' => 'view'
         ]]);
         $response = new Response();
 
-        $controller = $this->getMock('Cake\Controller\Controller', ['redirect'], [$request, $response]);
-
+        $controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setConstructorArgs([$request, $response])
+            ->setMethods(['redirect'])
+            ->getMock();
         $this->Authorizer->setController($controller);
 
         $set = $this->Authorizer->setCurrentParams();
@@ -115,7 +117,6 @@ class AuthorizerComponentTest extends TestCase
         $this->assertEmpty($this->Authorizer->getData());
 
         $this->Authorizer->action('index', function ($auth) {
-            
         });
 
         $this->assertNotEmpty($this->Authorizer->getData());
@@ -229,11 +230,10 @@ class AuthorizerComponentTest extends TestCase
     public function setUpRequest($params)
     {
         // Setup our component and fake test controller
-        $request = new Request(['params' => $params]);
-        $response = new Response();
-
-        $this->controller = $this->getMock('Cake\Controller\Controller', ['redirect'], [$request, $response]);
-
+        $this->controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setConstructorArgs([new ServerRequest(['params' => $params]), new Response()])
+            ->setMethods(['redirect'])
+            ->getMock();
         $this->controller->loadComponent('Auth');
 
         $this->controller->Auth->setUser([

--- a/tests/TestCase/Controller/Component/MenuComponentTest.php
+++ b/tests/TestCase/Controller/Component/MenuComponentTest.php
@@ -17,7 +17,9 @@ namespace Utils\Test\TestCase\Controller\Component;
 use Cake\Controller\ComponentRegistry;
 use Cake\Core\Configure;
 use Cake\Event\Event;
-use Cake\Network\Request;
+use Cake\Event\EventManager;
+use Cake\Http\Response;
+use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use Utils\Controller\Component\MenuComponent;
 
@@ -40,7 +42,12 @@ class MenuComponentTest extends TestCase
         $collection = new ComponentRegistry();
         $this->Menu = new MenuComponent($collection);
 
-        $this->Controller = $this->getMock('Cake\Controller\Controller', ['redirect', 'initMenuItems']);
+        // Setup our component and fake test controller
+        $this->Controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setConstructorArgs([new ServerRequest(), new Response()])
+            ->setMethods(['redirect', 'initMenuItems'])
+            ->getMock();
+        $this->Controller->request = new ServerRequest();
         $this->Menu->setController($this->Controller);
     }
 
@@ -123,7 +130,6 @@ class MenuComponentTest extends TestCase
         $this->Menu->add('Test01', []);
         $this->Menu->add('Test02', []);
 
-
         // get menu
         $test01 = $this->Menu->getMenu();
 
@@ -145,12 +151,14 @@ class MenuComponentTest extends TestCase
         Configure::write('Menu.Register.ConfigureItem2', []);
         Configure::write('Menu.Register.ConfigureItem3', []);
 
-        $request = new Request();
-        $this->Controller = $this->getMock('Cake\Controller\Controller', ['redirect', 'initMenuItems'], [$request]);
-
-        // Setup our component and fake test controller
-        $collection = new ComponentRegistry($this->Controller);
-        $this->Menu = new MenuComponent($collection);
+        $request = new ServerRequest();
+        $response = new Response();
+        $this->Controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setConstructorArgs([$request, $response])
+            ->setMethods(null)
+            ->getMock();
+        $registry = new ComponentRegistry($this->Controller);
+        $this->Menu = new MenuComponent($registry);
 
         $this->Menu->setController($this->Controller);
 

--- a/tests/TestCase/Controller/Component/SearchComponentTest.php
+++ b/tests/TestCase/Controller/Component/SearchComponentTest.php
@@ -16,6 +16,7 @@ namespace Utils\Test\TestCase\Controller\Component;
 
 use Cake\Controller\ComponentRegistry;
 use Cake\Event\Event;
+use Cake\Http\ServerRequest;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Utils\Controller\Component\SearchComponent;
@@ -31,7 +32,7 @@ class SearchComponentTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'Articles' => 'plugin.utils.articles'
+        'Articles' => 'plugin.Utils.Articles'
     ];
 
     /**
@@ -46,8 +47,9 @@ class SearchComponentTest extends TestCase
         // Setup our component and fake test controller
         $collection = new ComponentRegistry();
         $this->Search = new SearchComponent($collection);
-
-        $this->Controller = $this->getMock('Cake\Controller\Controller', ['redirect']);
+        $this->Controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['redirect'])
+            ->getMock();
         $this->Search->setController($this->Controller);
     }
 
@@ -73,11 +75,11 @@ class SearchComponentTest extends TestCase
      */
     public function testAddFilter()
     {
-        $this->assertEmpty($this->Search->config('filters'));
+        $this->assertEmpty($this->Search->getConfig('filters'));
 
         $this->Search->addFilter('TestFilter1');
 
-        $this->assertArrayHasKey('TestFilter1', $this->Search->config('filters'));
+        $this->assertArrayHasKey('TestFilter1', $this->Search->getConfig('filters'));
 
         $_settings = [
             'field' => 'TestFilter1',
@@ -90,7 +92,7 @@ class SearchComponentTest extends TestCase
             'options' => false
         ];
 
-        $this->assertEquals($_settings, $this->Search->config('filters.TestFilter1'));
+        $this->assertEquals($_settings, $this->Search->getConfig('filters.TestFilter1'));
 
         $this->Search->addFilter('TestFilter2', [
             'field' => 'customField',
@@ -118,7 +120,7 @@ class SearchComponentTest extends TestCase
             ]
         ];
 
-        $this->assertEquals($_settings, $this->Search->config('filters.TestFilter2'));
+        $this->assertEquals($_settings, $this->Search->getConfig('filters.TestFilter2'));
     }
 
     public function testRemoveFilter()
@@ -127,21 +129,21 @@ class SearchComponentTest extends TestCase
         $this->Search->addFilter('TestFilter2');
         $this->Search->addFilter('TestFilter3');
 
-        $this->assertArrayHasKey('TestFilter1', $this->Search->config('filters'));
-        $this->assertArrayHasKey('TestFilter2', $this->Search->config('filters'));
-        $this->assertArrayHasKey('TestFilter3', $this->Search->config('filters'));
+        $this->assertArrayHasKey('TestFilter1', $this->Search->getConfig('filters'));
+        $this->assertArrayHasKey('TestFilter2', $this->Search->getConfig('filters'));
+        $this->assertArrayHasKey('TestFilter3', $this->Search->getConfig('filters'));
 
         $this->Search->removeFilter('TestFilter3');
 
-        $this->assertArrayHasKey('TestFilter1', $this->Search->config('filters'));
-        $this->assertArrayHasKey('TestFilter2', $this->Search->config('filters'));
-        $this->assertArrayNotHasKey('TestFilter3', $this->Search->config('filters'));
+        $this->assertArrayHasKey('TestFilter1', $this->Search->getConfig('filters'));
+        $this->assertArrayHasKey('TestFilter2', $this->Search->getConfig('filters'));
+        $this->assertArrayNotHasKey('TestFilter3', $this->Search->getConfig('filters'));
 
         $this->Search->removeFilter('TestFilter2');
 
-        $this->assertArrayHasKey('TestFilter1', $this->Search->config('filters'));
-        $this->assertArrayNotHasKey('TestFilter2', $this->Search->config('filters'));
-        $this->assertArrayNotHasKey('TestFilter3', $this->Search->config('filters'));
+        $this->assertArrayHasKey('TestFilter1', $this->Search->getConfig('filters'));
+        $this->assertArrayNotHasKey('TestFilter2', $this->Search->getConfig('filters'));
+        $this->assertArrayNotHasKey('TestFilter3', $this->Search->getConfig('filters'));
     }
 
     /**
@@ -183,8 +185,12 @@ class SearchComponentTest extends TestCase
         $this->Search->addFilter('Title');
 
         // adding search querys
-        $this->Controller->request->query['Title'] = 'First Article';
-
+        $request = new ServerRequest(['query' => ['Title' => 'First Article']]);
+        $this->Controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setConstructorArgs([$request])
+            ->setMethods(['redirect', 'request'])
+            ->getMock();
+        $this->Search->setController($this->Controller);
         $search = $this->Search->search($query);
 
         $this->assertEquals(1, $search->Count());
@@ -211,8 +217,12 @@ class SearchComponentTest extends TestCase
         $this->Search->addFilter('Title');
 
         // adding search querys
-        $this->Controller->request->query['Title'] = 'Article';
-
+        $request = new ServerRequest(['query' => ['Title' => 'Article']]);
+        $this->Controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setConstructorArgs([$request])
+            ->setMethods(['redirect', 'request'])
+            ->getMock();
+        $this->Search->setController($this->Controller);
         $search = $this->Search->search($query);
 
         $this->assertEquals(3, $search->Count());

--- a/tests/TestCase/Model/Behavior/StateableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/StateableBehaviorTest.php
@@ -28,7 +28,7 @@ class StateableBehaviorTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['plugin.utils.articles'];
+    public $fixtures = ['plugin.Utils.Articles'];
 
     /**
      * setUp method
@@ -63,13 +63,14 @@ class StateableBehaviorTest extends TestCase
      */
     public function testStateList()
     {
+        $this->Model->addBehavior('Utils.Stateable');
         $_list = [
             'concept' => 0,
             'active' => 1,
             'deleted' => -1,
         ];
 
-        $this->assertEquals($_list, $this->Model->behaviors()->get('Stateable')->config('states'));
+        $this->assertEquals($_list, $this->Model->getBehavior('Stateable')->getConfig('states'));
 
         $_list = [
             0 => 'concept',
@@ -87,6 +88,7 @@ class StateableBehaviorTest extends TestCase
      */
     public function testFindConcept()
     {
+        $this->Model->addBehavior('Utils.Stateable');
         $data = $this->Model->find('concept')->toArray();
 
         $this->assertEquals(2, $data[0]['id']);
@@ -100,6 +102,7 @@ class StateableBehaviorTest extends TestCase
      */
     public function testFindActive()
     {
+        $this->Model->addBehavior('Utils.Stateable');
         $data = $this->Model->find('active')->toArray();
 
         $this->assertEquals(1, $data[0]['id']);
@@ -113,6 +116,7 @@ class StateableBehaviorTest extends TestCase
      */
     public function testFindDeleted()
     {
+        $this->Model->addBehavior('Utils.Stateable');
         $data = $this->Model->find('deleted')->toArray();
 
         $this->assertEquals(3, $data[0]['id']);

--- a/tests/TestCase/Model/Behavior/UploadableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UploadableBehaviorTest.php
@@ -28,7 +28,7 @@ class UploadableBehaviorTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['plugin.utils.articles'];
+    public $fixtures = ['plugin.Utils.Articles'];
 
     /**
      * setUp method
@@ -40,10 +40,10 @@ class UploadableBehaviorTest extends TestCase
         parent::setUp();
 
         $connection = ConnectionManager::get('test');
-
-        $this->Articles = $this->getMock('Cake\ORM\Table', ['_mkdir', '_moveUploadedFile'], [
-            ['table' => 'articles', 'connection' => $connection]
-        ]);
+        $this->Articles = $this->getMockBuilder('Cake\ORM\Table')
+            ->setConstructorArgs([['table' => 'articles', 'connection' => $connection]])
+            ->setMethods(['_mkdir', '_moveUploadedFile'])
+            ->getMock();
     }
 
     /**
@@ -170,11 +170,12 @@ class UploadableBehaviorTest extends TestCase
     {
         $connection = ConnectionManager::get('test');
 
-        $table = $this->getMock('Cake\ORM\Table', ['_nonExistingMethodElseTheMockWillMockAllMethods'], [
-            ['table' => 'articles', 'connection' => $connection]
-        ]);
+        $table = $this->getMockBuilder('Cake\ORM\Table')
+            ->setConstructorArgs([['table' => 'articles', 'connection' => $connection]])
+            ->setMethods(['_nonExistingMethodElseTheMockWillMockAllMethods'])
+            ->getMock();
 
-        $table->alias("Articles");
+        $table->setAlias("Articles");
 
         $behaviorOptions = [
             'file' => [
@@ -191,7 +192,10 @@ class UploadableBehaviorTest extends TestCase
 
         $mocks = ['_mkdir', '_MoveUploadedFile'];
 
-        $behaviorMock = $this->getMock('\Utils\Model\Behavior\UploadableBehavior', $mocks, [$table, $behaviorOptions]);
+        $behaviorMock = $this->getMockBuilder('\Utils\Model\Behavior\UploadableBehavior')
+            ->setConstructorArgs([$table, $behaviorOptions])
+            ->setMethods($mocks)
+            ->getMock();
 
         $behaviorMock->expects($this->any())
             ->method('_mkdir')
@@ -201,7 +205,6 @@ class UploadableBehaviorTest extends TestCase
             ->will($this->returnValue(true));
 
         $table->behaviors()->set('Uploadable', $behaviorMock);
-
 
         $data = [
             'id' => 3,

--- a/tests/TestCase/Model/Behavior/WhoDidItBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/WhoDidItBehaviorTest.php
@@ -29,8 +29,8 @@ class WhoDidItBehaviorTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.utils.articles',
-        'plugin.utils.users'
+        'plugin.Utils.Articles',
+        'plugin.Utils.Users'
     ];
 
     /**
@@ -69,15 +69,15 @@ class WhoDidItBehaviorTest extends TestCase
     {
         $behavior = $this->Model->behaviors()->get('WhoDidIt');
 
-        $behavior->config('fields', ['id', 'email']);
+        $behavior->setConfig('fields', ['id', 'email']);
 
         $data = $this->Model->get(1);
 
         $this->assertEquals(2, count($data->createdBy->toArray()));
         $this->assertEquals(2, count($data->modifiedBy->toArray()));
 
-        $behavior->config('fields', null);
-        $behavior->config('fields', []);
+        $behavior->setConfig('fields', null);
+        $behavior->setConfig('fields', []);
     }
 
     /**
@@ -88,14 +88,14 @@ class WhoDidItBehaviorTest extends TestCase
     {
         $behavior = $this->Model->behaviors()->get('WhoDidIt');
 
-        $behavior->config('modified_by', false);
+        $behavior->setConfig('modified_by', false);
 
         $data = $this->Model->get(1);
 
         $this->assertEquals(8, count($data->createdBy->toArray()));
         $this->assertNull($data->modifiedBy);
 
-        $behavior->config('modified_by', 'modified_by');
+        $behavior->setConfig('modified_by', 'modified_by');
     }
 
     /**

--- a/tests/TestCase/View/Helper/SearchHelperTest.php
+++ b/tests/TestCase/View/Helper/SearchHelperTest.php
@@ -79,11 +79,11 @@ class SearchHelperTest extends TestCase
 
         parent::tearDown();
     }
-    
+
     public function testFilterForm()
     {
         $result = $this->Search->filterForm($this->data);
-        
+
         $this->assertContains('<form method="get" accept-charset="utf-8" action="/">', $result);
         $this->assertContains('<input type="text" name="title" placeholder="title" id="title"/>', $result);
         $this->assertContains('<select name="category" placeholder="category" id="category">', $result);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -51,7 +51,7 @@ mb_internal_encoding('UTF-8');
 
 Configure::write('debug', true);
 Configure::write('App', [
-    'namespace' => 'Utils\Test\App',
+    'namespace' => 'App',
     'encoding' => 'UTF-8',
     'base' => false,
     'baseUrl' => false,
@@ -68,7 +68,7 @@ Configure::write('App', [
     ]
 ]);
 
-Cache::config([
+Cache::setConfig([
     '_cake_core_' => [
         'engine' => 'File',
         'prefix' => 'cake_core_',
@@ -87,7 +87,7 @@ if (!getenv('db_class')) {
     putenv('db_dsn=sqlite::memory:');
 }
 
-ConnectionManager::config('test', [
+ConnectionManager::setConfig('test', [
     'className' => 'Cake\Database\Connection',
     'driver' => getenv('db_class'),
     'dsn' => getenv('db_dsn'),
@@ -101,7 +101,7 @@ Configure::write('Session', [
     'defaults' => 'php'
 ]);
 
-Log::config([
+Log::setConfig([
     'debug' => [
         'engine' => 'Cake\Log\Engine\FileLog',
         'levels' => ['notice', 'info', 'debug'],
@@ -114,9 +114,7 @@ Log::config([
     ]
 ]);
 
-Plugin::load('Utils', ['path' => ROOT, 'bootstrap' => true, 'routes' => true]);
-
-Carbon\Carbon::setTestNow(Carbon\Carbon::now());
+Cake\Chronos\Chronos::setTestNow(Cake\Chronos\Chronos::now());
 
 DispatcherFactory::add('Routing');
 DispatcherFactory::add('ControllerFactory');


### PR DESCRIPTION
This PR removes the deprecation errors generated when using CakePHP 3.7
Namely:
- Many accessor/setters needs to be prefixed with set/get
- Fixtures needs to be in Camelcased format not in underscore format in the tests
- Recent phpunit required to modify the mocking some places

I have also done adjusments on the tests and the Travis config to make the tests working again.
This includes the following changes:

- Added explicit whitelist to the phpunit config (see https://github.com/sebastianbergmann/phpunit/issues/1932)
- Set minimum PHP version to PHP 5.6
- Use php-coveralls  from php-coveralls 
- Use phpunit from the vendor dir not the travis system's 

The PR is based on @mfrascati 's #38  PR, so when merging it that PR can be closed.
Many thanks to admad and challgren for the help on the CakePHP slack channel. Without them it would have taken much more time to do the fixing. 