### PR TITLE
Update deprecated calls, improve WhoDidItBehavior::beforeFind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/.buildpath
+/.project
+/.settings/
+/vendor/
+/composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,9 @@ before_script:
   - set +H
 
 script:
-  - sh -c "if [ '$DEFAULT' = '1' ]; then phpunit --stderr; fi"
+  - sh -c "if [ '$DEFAULT' = '1' ]; then vendor/bin/phpunit --stderr; fi"
   - sh -c "if [ '$PHPCS' = '1' ]; then ./vendor/bin/phpcs -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi"
-  - sh -c "if [ '$COVERALLS' = '1' ]; then phpunit --stderr --coverage-clover build/logs/clover.xml; fi"
+  - sh -c "if [ '$COVERALLS' = '1' ]; then vendor/bin/phpunit --stderr --coverage-clover build/logs/clover.xml; fi"
   - sh -c "if [ '$COVERALLS' = '1' ]; then php vendor/bin/coveralls -c .coveralls.yml -v; fi"
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_script:
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi"
   - sh -c "if [ '$PHPCS' = '1' ]; then composer require cakephp/cakephp-codesniffer:dev-master; fi"
-  - sh -c "if [ '$COVERALLS' = '1' ]; then composer require --dev satooshi/php-coveralls:dev-master; fi"
+  - sh -c "if [ '$COVERALLS' = '1' ]; then composer require --dev php-coveralls/php-coveralls; fi"
   - sh -c "if [ '$COVERALLS' = '1' ]; then mkdir -p build/logs; fi"
 
   - phpenv rehash
@@ -46,7 +46,7 @@ script:
   - sh -c "if [ '$DEFAULT' = '1' ]; then vendor/bin/phpunit --stderr; fi"
   - sh -c "if [ '$PHPCS' = '1' ]; then ./vendor/bin/phpcs -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi"
   - sh -c "if [ '$COVERALLS' = '1' ]; then vendor/bin/phpunit --stderr --coverage-clover build/logs/clover.xml; fi"
-  - sh -c "if [ '$COVERALLS' = '1' ]; then php vendor/bin/coveralls -c .coveralls.yml -v; fi"
+  - sh -c "if [ '$COVERALLS' = '1' ]; then php vendor/bin/php-coveralls -v; fi"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ env:
   global:
     - DEFAULT=1
 
+services:
+  - postgresql
+  - mysql
+
 matrix:
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,14 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
 
 sudo: false
 
 env:
   matrix:
-    - DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
-    - DB=pgsql db_dsn='postgres://travis@127.0.0.1/cakephp_test'
+    - DB=mysql db_dsn='mysql://root@127.0.0.1/cakephp_test'
+    - DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
     - DB=sqlite db_dsn='sqlite:///:memory:'
 
   global:
@@ -20,11 +18,11 @@ matrix:
   fast_finish: true
 
   include:
-  - php: 5.5
+  - php: 5.6
     env: PHPCS=1 DEFAULT=0
 
-  - php: 5.5
-    env: COVERALLS=1 DEFAULT=0 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
+  - php: 5.6
+    env: COVERALLS=1 DEFAULT=0 DB=mysql db_dsn='mysql://root@127.0.0.1/cakephp_test'
 
 install:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "cakephp/cakephp": "~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "*"
+        "phpunit/phpunit": "^5|^6"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -31,7 +31,7 @@
 
     <!-- Prevent coverage reports from looking in tests and vendors -->
     <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+        <whitelist processUncoveredFilesFromWhitelist="false">
             <directory suffix=".php">./src</directory>
             <directory suffix=".ctp">./src</directory>
         </whitelist>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -31,6 +31,10 @@
 
     <!-- Prevent coverage reports from looking in tests and vendors -->
     <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+            <directory suffix=".ctp">./src</directory>
+        </whitelist>
         <blacklist>
             <directory suffix=".php">./vendor/</directory>
             <directory suffix=".ctp">./vendor/</directory>

--- a/src/Controller/Component/AuthorizerComponent.php
+++ b/src/Controller/Component/AuthorizerComponent.php
@@ -108,9 +108,9 @@ class AuthorizerComponent extends Component
      */
     public function setCurrentParams()
     {
-        $this->_current['plugin'] = $this->Controller->request->params['plugin'];
-        $this->_current['controller'] = $this->Controller->request->params['controller'];
-        $this->_current['action'] = $this->Controller->request->params['action'];
+        $this->_current['plugin'] = $this->Controller->request->getParam('plugin');
+        $this->_current['controller'] = $this->Controller->request->getParam('controller');
+        $this->_current['action'] = $this->Controller->request->getParam('action');
 
         return $this->_current;
     }
@@ -284,7 +284,7 @@ class AuthorizerComponent extends Component
     public function authorize()
     {
         $user = $this->Controller->Auth->user();
-        $role = $user[$this->config('roleField')];
+        $role = $user[$this->getConfig('roleField')];
 
         $controller = $this->_current['controller'];
         $action = $this->_current['action'];

--- a/src/Controller/Component/AuthorizerComponent.php
+++ b/src/Controller/Component/AuthorizerComponent.php
@@ -148,7 +148,6 @@ class AuthorizerComponent extends Component
             $actions = [$actions];
         }
 
-
         $controller = $this->_current['controller'];
 
         foreach ($actions as $action) {
@@ -347,7 +346,6 @@ class AuthorizerComponent extends Component
         if (!is_bool($state)) {
             $state = false;
         }
-
 
         return $state;
     }

--- a/src/Controller/Component/MenuComponent.php
+++ b/src/Controller/Component/MenuComponent.php
@@ -134,6 +134,7 @@ class MenuComponent extends Component
         if ($area !== null) {
             $this->area = $area;
         }
+
         return $this->area;
     }
 

--- a/src/Controller/Component/MenuComponent.php
+++ b/src/Controller/Component/MenuComponent.php
@@ -110,7 +110,7 @@ class MenuComponent extends Component
      */
     public function beforeFilter($event)
     {
-        $this->setController($event->subject());
+        $this->setController($event->getSubject());
 
         if (method_exists($this->Controller, 'initMenuItems')) {
             $this->Controller->initMenuItems($event);
@@ -230,9 +230,9 @@ class MenuComponent extends Component
         $item = array_merge($_item, $item);
 
         $url = Router::url($item['url']);
-        $actives = $this->config('active');
+        $actives = $this->getConfig('active');
 
-        if ($url === Router::url("/" . $this->Controller->request->url)) {
+        if ($url === Router::url("/" . $this->Controller->request->getPath())) {
             $item['active'] = true;
         }
 

--- a/src/Controller/Component/SearchComponent.php
+++ b/src/Controller/Component/SearchComponent.php
@@ -193,6 +193,7 @@ class SearchComponent extends Component
         if ($options['operator'] === 'LIKE') {
             $string .= ' LIKE';
         }
+
         return $string;
     }
 
@@ -217,6 +218,7 @@ class SearchComponent extends Component
         if ($options['operator'] === 'LIKE') {
             $string .= '%';
         }
+
         return $string;
     }
 

--- a/src/Controller/Component/SearchComponent.php
+++ b/src/Controller/Component/SearchComponent.php
@@ -85,7 +85,7 @@ class SearchComponent extends Component
      */
     public function beforeRender($event)
     {
-        $this->Controller->set('searchFilters', $this->_normalize($this->config('filters')));
+        $this->Controller->set('searchFilters', $this->_normalize($this->getConfig('filters')));
     }
 
     /**
@@ -106,14 +106,14 @@ class SearchComponent extends Component
      */
     public function addFilter($name, $options = [])
     {
-        $_options = $this->config('_default');
+        $_options = $this->getConfig('_default');
 
         $_options['field'] = $name;
         $_options['column'] = $name;
 
         $options = array_merge($_options, $options);
 
-        $this->config('filters.' . $name, $options, true);
+        $this->setConfig('filters.' . $name, $options, true);
     }
 
     /**
@@ -126,10 +126,10 @@ class SearchComponent extends Component
      */
     public function removeFilter($name)
     {
-        $filters = $this->config('filters');
+        $filters = $this->getConfig('filters');
         unset($filters[$name]);
 
-        $this->config('filters', $filters, false);
+        $this->setConfig('filters', $filters, false);
     }
 
     /**
@@ -154,11 +154,11 @@ class SearchComponent extends Component
      */
     public function search(\Cake\ORM\Query $query, $options = [])
     {
-        $_query = $this->Controller->request->query;
-        $this->Controller->request->data = $_query;
+        $_query = $this->Controller->request->getQuery();
+        $this->Controller->request->withParsedBody($_query);
 
         $params = $_query;
-        $filters = $this->_normalize($this->config('filters'));
+        $filters = $this->_normalize($this->getConfig('filters'));
 
         foreach ($filters as $field => $options) {
             $hash = Hash::get($params, $options['column']);
@@ -237,7 +237,7 @@ class SearchComponent extends Component
         $key = 'filters.' . $field . '.attributes.value';
         $value = Hash::get($params, $options['column']);
 
-        $this->config($key, $value);
+        $this->setConfig($key, $value);
     }
 
     /**

--- a/src/Model/Behavior/IsOwnedByBehavior.php
+++ b/src/Model/Behavior/IsOwnedByBehavior.php
@@ -53,7 +53,7 @@ class IsOwnedByBehavior extends Behavior
             return false;
         }
 
-        $itemUserId = $item[$this->config('column')];
+        $itemUserId = $item[$this->getConfig('column')];
         $userId = $user['id'];
 
         if ($itemUserId === $userId) {

--- a/src/Model/Behavior/StateableBehavior.php
+++ b/src/Model/Behavior/StateableBehavior.php
@@ -50,7 +50,7 @@ class StateableBehavior extends Behavior
      */
     public function stateList()
     {
-        return array_flip($this->config('states'));
+        return array_flip($this->getConfig('states'));
     }
 
     /**
@@ -65,7 +65,7 @@ class StateableBehavior extends Behavior
     public function findConcept($query, $options)
     {
         $query->where([
-            $this->config('field') => $this->config('states.concept'),
+            $this->getConfig('field') => $this->getConfig('states.concept'),
         ]);
 
         return $query;
@@ -83,7 +83,7 @@ class StateableBehavior extends Behavior
     public function findActive($query, $options)
     {
         $query->where([
-            $this->config('field') => $this->config('states.active'),
+            $this->getConfig('field') => $this->getConfig('states.active'),
         ]);
 
         return $query;
@@ -101,7 +101,7 @@ class StateableBehavior extends Behavior
     public function findDeleted($query, $options)
     {
         $query->where([
-            $this->config('field') => $this->config('states.deleted'),
+            $this->getConfig('field') => $this->getConfig('states.deleted'),
         ]);
 
         return $query;

--- a/src/Model/Behavior/UploadableBehavior.php
+++ b/src/Model/Behavior/UploadableBehavior.php
@@ -213,6 +213,7 @@ class UploadableBehavior extends Behavior
                 $list[$field] = $fieldConfig;
             }
         }
+
         return $list;
     }
 
@@ -234,6 +235,7 @@ class UploadableBehavior extends Behavior
                 return true;
             }
         }
+
         return false;
     }
 
@@ -261,6 +263,7 @@ class UploadableBehavior extends Behavior
         if ($this->_moveUploadedFile($_upload['tmp_name'], $uploadPath)) {
             return true;
         }
+
         return false;
     }
 
@@ -304,6 +307,7 @@ class UploadableBehavior extends Behavior
                 }
             }
         }
+
         return $entity;
     }
 
@@ -419,6 +423,7 @@ class UploadableBehavior extends Behavior
     protected function _getUrl($entity, $field)
     {
         $path = '/' . $this->_getPath($entity, $field, ['root' => false, 'file' => true]);
+
         return str_replace(DS, '/', $path);
     }
 
@@ -509,8 +514,10 @@ class UploadableBehavior extends Behavior
             if (count($folder->find()) === 0) {
                 $folder->delete();
             }
+
             return true;
         }
+
         return false;
     }
 }

--- a/src/Model/Behavior/UploadableBehavior.php
+++ b/src/Model/Behavior/UploadableBehavior.php
@@ -88,11 +88,11 @@ class UploadableBehavior extends Behavior
 
         Type::map('Utils.File', 'Utils\Database\Type\FileType');
 
-        $schema = $table->schema();
+        $schema = $table->getSchema();
         foreach ($this->getFieldList() as $field => $settings) {
-            $schema->columnType($field, 'Utils.File');
+            $schema->setColumnType($field, 'Utils.File');
         }
-        $table->schema($schema);
+        $table->setSchema($schema);
 
         $this->_Table = $table;
     }
@@ -116,7 +116,7 @@ class UploadableBehavior extends Behavior
             }
 
             if (!$entity->isNew()) {
-                $dirtyField = $entity->dirty($field);
+                $dirtyField = $entity->isDirty($field);
                 $originalField = $entity->getOriginal($field);
                 if ($dirtyField && !is_null($originalField) && !is_array($originalField)) {
                     $fieldConfig = $this->config($field);
@@ -153,7 +153,7 @@ class UploadableBehavior extends Behavior
             }
         }
         foreach ($storedToSave as $toSave) {
-            $event->subject()->save($toSave);
+            $event->getSubject()->save($toSave);
         }
         $this->_savedFields = [];
     }
@@ -196,7 +196,7 @@ class UploadableBehavior extends Behavior
 
         $list = [];
 
-        foreach ($this->config() as $key => $value) {
+        foreach ($this->getConfig() as $key => $value) {
             if (!in_array($key, $this->_presetConfigKeys) || is_integer($key)) {
                 if (is_integer($key)) {
                     $field = $value;
@@ -281,7 +281,7 @@ class UploadableBehavior extends Behavior
      */
     protected function _setUploadColumns($entity, $field, $options = [])
     {
-        $fieldConfig = $this->config($field);
+        $fieldConfig = $this->getConfig($field);
         $_upload = $this->_uploads[$field];
 
         // set all columns with values
@@ -332,13 +332,13 @@ class UploadableBehavior extends Behavior
 
         $options = Hash::merge($_options, $options);
 
-        $data = $this->config($field);
+        $data = $this->getConfig($field);
 
         if (is_null($data)) {
-            foreach ($this->config() as $key => $config) {
+            foreach ($this->getConfig() as $key => $config) {
                 if ($config == $field) {
                     if ($options['save']) {
-                        $this->config($field, []);
+                        $this->setConfig($field, []);
 
                         $this->_configDelete($key);
                     }
@@ -353,10 +353,10 @@ class UploadableBehavior extends Behavior
             $data = Hash::insert($data, 'fields.filePath', $field);
         }
 
-        $data = Hash::merge($this->config('defaultFieldConfig'), $data);
+        $data = Hash::merge($this->getConfig('defaultFieldConfig'), $data);
 
         if ($options['save']) {
-            $this->config($field, $data);
+            $this->setConfig($field, $data);
         }
 
         return $data;
@@ -385,7 +385,7 @@ class UploadableBehavior extends Behavior
 
         $options = Hash::merge($_options, $options);
 
-        $config = $this->config($field);
+        $config = $this->getConfig($field);
 
         $path = $config['path'];
 
@@ -393,7 +393,7 @@ class UploadableBehavior extends Behavior
             '{ROOT}' => ROOT,
             '{WEBROOT}' => 'webroot',
             '{field}' => $entity->get($config['field']),
-            '{model}' => Inflector::underscore($this->_Table->alias()),
+            '{model}' => Inflector::underscore($this->_Table->getAlias()),
             '{DS}' => DIRECTORY_SEPARATOR,
             '\\' => DIRECTORY_SEPARATOR,
         ];
@@ -444,7 +444,7 @@ class UploadableBehavior extends Behavior
 
         $options = Hash::merge($_options, $options);
 
-        $config = $this->config($field);
+        $config = $this->getConfig($field);
 
         $_upload = $this->_uploads[$field];
 

--- a/src/Model/Behavior/WhoDidItBehavior.php
+++ b/src/Model/Behavior/WhoDidItBehavior.php
@@ -66,19 +66,19 @@ class WhoDidItBehavior extends Behavior
 
         $this->Table = $table;
 
-        if ($this->config('created_by')) {
+        if ($this->getConfig('created_by')) {
             $this->Table->belongsTo('CreatedBy', [
-                'foreignKey' => $this->config('created_by'),
-                'className' => $this->config('userModel'),
-                'propertyName' => $this->config('createdByPropertyName')
+                'foreignKey' => $this->getConfig('created_by'),
+                'className' => $this->getConfig('userModel'),
+                'propertyName' => $this->getConfig('createdByPropertyName')
             ]);
         }
 
-        if ($this->config('modified_by')) {
+        if ($this->getConfig('modified_by')) {
             $this->Table->belongsTo('ModifiedBy', [
-                'foreignKey' => $this->config('modified_by'),
-                'className' => $this->config('userModel'),
-                'propertyName' => $this->config('modifiedByPropertyName')
+                'foreignKey' => $this->getConfig('modified_by'),
+                'className' => $this->getConfig('userModel'),
+                'propertyName' => $this->getConfig('modifiedByPropertyName')
             ]);
         }
     }
@@ -109,13 +109,14 @@ class WhoDidItBehavior extends Behavior
      */
     public function beforeFind($event, $query, $options, $primary)
     {
-        if ($this->config('contain')) {
-            if ($this->config('created_by')) {
-                $query->contain(['CreatedBy' => ['fields' => $this->config('fields')]]);
+        $contain = $query->getContain();
+        if ($this->getConfig('contain') || isset($contain['CreatedBy']) || isset($contain['ModifiedBy'])) {
+            if ($this->getConfig('created_by')) {
+                $query->contain(['CreatedBy' => ['fields' => $this->getConfig('fields')]]);
             }
 
-            if ($this->config('modified_by')) {
-                $query->contain(['ModifiedBy' => ['fields' => $this->config('fields')]]);
+            if ($this->getConfig('modified_by')) {
+                $query->contain(['ModifiedBy' => ['fields' => $this->getConfig('fields')]]);
             }
         }
     }
@@ -136,13 +137,13 @@ class WhoDidItBehavior extends Behavior
         $id = $auth['id'];
 
         if ($entity->isNew()) {
-            if ($this->config('created_by')) {
-                $entity->set($this->config('created_by'), $id);
+            if ($this->getConfig('created_by')) {
+                $entity->set($this->getConfig('created_by'), $id);
             }
         }
 
-        if ($this->config('modified_by')) {
-            $entity->set($this->config('modified_by'), $id);
+        if ($this->getConfig('modified_by')) {
+            $entity->set($this->getConfig('modified_by'), $id);
         }
     }
 }

--- a/src/View/Helper/SearchHelper.php
+++ b/src/View/Helper/SearchHelper.php
@@ -63,7 +63,7 @@ class SearchHelper extends Helper
             if ($field['options']) {
                 $field['attributes']['options'] = $field['options'];
             }
-            $html .= $this->Form->input($field['column'], $field['attributes']);
+            $html .= $this->Form->control($field['column'], $field['attributes']);
             $html .= ' ';
         }
 

--- a/tests/TestCase/Controller/Component/AuthorizerComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthorizerComponentTest.php
@@ -115,7 +115,6 @@ class AuthorizerComponentTest extends TestCase
         $this->assertEmpty($this->Authorizer->getData());
 
         $this->Authorizer->action('index', function ($auth) {
-            
         });
 
         $this->assertNotEmpty($this->Authorizer->getData());

--- a/tests/TestCase/Controller/Component/AuthorizerComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthorizerComponentTest.php
@@ -15,8 +15,8 @@
 namespace Utils\Test\TestCase\Controller\Component;
 
 use Cake\Controller\ComponentRegistry;
-use Cake\Http\ServerRequest;
 use Cake\Http\Response;
+use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
 use Utils\Controller\Component\AuthorizerComponent;

--- a/tests/TestCase/Controller/Component/AuthorizerComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthorizerComponentTest.php
@@ -15,8 +15,8 @@
 namespace Utils\Test\TestCase\Controller\Component;
 
 use Cake\Controller\ComponentRegistry;
-use Cake\Network\Request;
-use Cake\Network\Response;
+use Cake\Http\ServerRequest;
+use Cake\Http\Response;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
 use Utils\Controller\Component\AuthorizerComponent;
@@ -87,14 +87,17 @@ class AuthorizerComponentTest extends TestCase
         $this->assertEquals("index", $set['action']);
 
         // Setup our component and fake test controller
-        $request = new Request(['params' => [
-                'plugin' => 'utils',
-                'controller' => 'bookmarks',
-                'action' => 'view'
+        $request = new ServerRequest(['params' => [
+            'plugin' => 'utils',
+            'controller' => 'bookmarks',
+            'action' => 'view',
         ]]);
         $response = new Response();
 
-        $controller = $this->getMock('Cake\Controller\Controller', ['redirect'], [$request, $response]);
+        $controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setConstructorArgs([$request, $response])
+            ->setMethods(['redirect'])
+            ->getMock();
 
         $this->Authorizer->setController($controller);
 
@@ -228,11 +231,13 @@ class AuthorizerComponentTest extends TestCase
     public function setUpRequest($params)
     {
         // Setup our component and fake test controller
-        $request = new Request(['params' => $params]);
+        $request = new ServerRequest(['params' => $params]);
         $response = new Response();
 
-        $this->controller = $this->getMock('Cake\Controller\Controller', ['redirect'], [$request, $response]);
-
+        $this->controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setConstructorArgs([$request, $response])
+            ->setMethods(['redirect'])
+            ->getMock();
         $this->controller->loadComponent('Auth');
 
         $this->controller->Auth->setUser([

--- a/tests/TestCase/Controller/Component/MenuComponentTest.php
+++ b/tests/TestCase/Controller/Component/MenuComponentTest.php
@@ -40,7 +40,9 @@ class MenuComponentTest extends TestCase
         $collection = new ComponentRegistry();
         $this->Menu = new MenuComponent($collection);
 
-        $this->Controller = $this->getMock('Cake\Controller\Controller', ['redirect', 'initMenuItems']);
+        $this->Controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['redirect', 'initMenuItems'])
+            ->getMock();
         $this->Menu->setController($this->Controller);
     }
 
@@ -145,7 +147,10 @@ class MenuComponentTest extends TestCase
         Configure::write('Menu.Register.ConfigureItem3', []);
 
         $request = new Request();
-        $this->Controller = $this->getMock('Cake\Controller\Controller', ['redirect', 'initMenuItems'], [$request]);
+        $this->Controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setConstructorArgs([$request])
+            ->setMethods(['redirect', 'initMenuItems'])
+            ->getMock();
 
         // Setup our component and fake test controller
         $collection = new ComponentRegistry($this->Controller);

--- a/tests/TestCase/Controller/Component/MenuComponentTest.php
+++ b/tests/TestCase/Controller/Component/MenuComponentTest.php
@@ -123,7 +123,6 @@ class MenuComponentTest extends TestCase
         $this->Menu->add('Test01', []);
         $this->Menu->add('Test02', []);
 
-
         // get menu
         $test01 = $this->Menu->getMenu();
 

--- a/tests/TestCase/Controller/Component/SearchComponentTest.php
+++ b/tests/TestCase/Controller/Component/SearchComponentTest.php
@@ -16,6 +16,7 @@ namespace Utils\Test\TestCase\Controller\Component;
 
 use Cake\Controller\ComponentRegistry;
 use Cake\Event\Event;
+use Cake\Http\ServerRequest;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Utils\Controller\Component\SearchComponent;
@@ -47,7 +48,9 @@ class SearchComponentTest extends TestCase
         $collection = new ComponentRegistry();
         $this->Search = new SearchComponent($collection);
 
-        $this->Controller = $this->getMock('Cake\Controller\Controller', ['redirect']);
+        $this->Controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setMethods(['redirect'])
+            ->getMock();
         $this->Search->setController($this->Controller);
     }
 
@@ -73,11 +76,11 @@ class SearchComponentTest extends TestCase
      */
     public function testAddFilter()
     {
-        $this->assertEmpty($this->Search->config('filters'));
+        $this->assertEmpty($this->Search->getConfig('filters'));
 
         $this->Search->addFilter('TestFilter1');
 
-        $this->assertArrayHasKey('TestFilter1', $this->Search->config('filters'));
+        $this->assertArrayHasKey('TestFilter1', $this->Search->getConfig('filters'));
 
         $_settings = [
             'field' => 'TestFilter1',
@@ -90,7 +93,7 @@ class SearchComponentTest extends TestCase
             'options' => false
         ];
 
-        $this->assertEquals($_settings, $this->Search->config('filters.TestFilter1'));
+        $this->assertEquals($_settings, $this->Search->getConfig('filters.TestFilter1'));
 
         $this->Search->addFilter('TestFilter2', [
             'field' => 'customField',
@@ -118,7 +121,7 @@ class SearchComponentTest extends TestCase
             ]
         ];
 
-        $this->assertEquals($_settings, $this->Search->config('filters.TestFilter2'));
+        $this->assertEquals($_settings, $this->Search->getConfig('filters.TestFilter2'));
     }
 
     public function testRemoveFilter()
@@ -127,21 +130,21 @@ class SearchComponentTest extends TestCase
         $this->Search->addFilter('TestFilter2');
         $this->Search->addFilter('TestFilter3');
 
-        $this->assertArrayHasKey('TestFilter1', $this->Search->config('filters'));
-        $this->assertArrayHasKey('TestFilter2', $this->Search->config('filters'));
-        $this->assertArrayHasKey('TestFilter3', $this->Search->config('filters'));
+        $this->assertArrayHasKey('TestFilter1', $this->Search->getConfig('filters'));
+        $this->assertArrayHasKey('TestFilter2', $this->Search->getConfig('filters'));
+        $this->assertArrayHasKey('TestFilter3', $this->Search->getConfig('filters'));
 
         $this->Search->removeFilter('TestFilter3');
 
-        $this->assertArrayHasKey('TestFilter1', $this->Search->config('filters'));
-        $this->assertArrayHasKey('TestFilter2', $this->Search->config('filters'));
-        $this->assertArrayNotHasKey('TestFilter3', $this->Search->config('filters'));
+        $this->assertArrayHasKey('TestFilter1', $this->Search->getConfig('filters'));
+        $this->assertArrayHasKey('TestFilter2', $this->Search->getConfig('filters'));
+        $this->assertArrayNotHasKey('TestFilter3', $this->Search->getConfig('filters'));
 
         $this->Search->removeFilter('TestFilter2');
 
-        $this->assertArrayHasKey('TestFilter1', $this->Search->config('filters'));
-        $this->assertArrayNotHasKey('TestFilter2', $this->Search->config('filters'));
-        $this->assertArrayNotHasKey('TestFilter3', $this->Search->config('filters'));
+        $this->assertArrayHasKey('TestFilter1', $this->Search->getConfig('filters'));
+        $this->assertArrayNotHasKey('TestFilter2', $this->Search->getConfig('filters'));
+        $this->assertArrayNotHasKey('TestFilter3', $this->Search->getConfig('filters'));
     }
 
     /**
@@ -183,7 +186,16 @@ class SearchComponentTest extends TestCase
         $this->Search->addFilter('Title');
 
         // adding search querys
-        $this->Controller->request->query['Title'] = 'First Article';
+        $request = new ServerRequest([
+            'query' => [
+                'Title' => 'First Article',
+            ],
+        ]);
+        $this->Controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setConstructorArgs([$request])
+            ->setMethods(['redirect'])
+            ->getMock();
+        $this->Search->setController($this->Controller);
 
         $search = $this->Search->search($query);
 
@@ -211,7 +223,16 @@ class SearchComponentTest extends TestCase
         $this->Search->addFilter('Title');
 
         // adding search querys
-        $this->Controller->request->query['Title'] = 'Article';
+        $request = new ServerRequest([
+            'query' => [
+                'Title' => 'Article',
+            ],
+        ]);
+        $this->Controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->setConstructorArgs([$request])
+            ->setMethods(['redirect'])
+            ->getMock();
+        $this->Search->setController($this->Controller);
 
         $search = $this->Search->search($query);
 

--- a/tests/TestCase/Controller/Component/SearchComponentTest.php
+++ b/tests/TestCase/Controller/Component/SearchComponentTest.php
@@ -31,7 +31,7 @@ class SearchComponentTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'Articles' => 'plugin.utils.articles'
+        'Articles' => 'plugin.Utils.Articles',
     ];
 
     /**

--- a/tests/TestCase/Model/Behavior/StateableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/StateableBehaviorTest.php
@@ -69,7 +69,7 @@ class StateableBehaviorTest extends TestCase
             'deleted' => -1,
         ];
         $this->Model->addBehavior('Utils.Stateable');
-        $this->assertEquals($_list, $this->Model->behaviors()->get('Utils.Stateable')->config('states'));
+        $this->assertEquals($_list, $this->Model->behaviors()->get('Stateable')->getConfig('states'));
 
         $_list = [
             0 => 'concept',
@@ -87,6 +87,7 @@ class StateableBehaviorTest extends TestCase
      */
     public function testFindConcept()
     {
+        $this->Model->addBehavior('Utils.Stateable');
         $data = $this->Model->find('concept')->toArray();
 
         $this->assertEquals(2, $data[0]['id']);
@@ -100,6 +101,7 @@ class StateableBehaviorTest extends TestCase
      */
     public function testFindActive()
     {
+        $this->Model->addBehavior('Utils.Stateable');
         $data = $this->Model->find('active')->toArray();
 
         $this->assertEquals(1, $data[0]['id']);
@@ -113,6 +115,7 @@ class StateableBehaviorTest extends TestCase
      */
     public function testFindDeleted()
     {
+        $this->Model->addBehavior('Utils.Stateable');
         $data = $this->Model->find('deleted')->toArray();
 
         $this->assertEquals(3, $data[0]['id']);

--- a/tests/TestCase/Model/Behavior/StateableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/StateableBehaviorTest.php
@@ -28,7 +28,7 @@ class StateableBehaviorTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['plugin.utils.articles'];
+    public $fixtures = ['plugin.Utils.Articles'];
 
     /**
      * setUp method

--- a/tests/TestCase/Model/Behavior/StateableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/StateableBehaviorTest.php
@@ -69,7 +69,7 @@ class StateableBehaviorTest extends TestCase
             'deleted' => -1,
         ];
 
-        $this->assertEquals($_list, $this->Model->behaviors()->get('Stateable')->config('states'));
+        $this->assertEquals($_list, $this->Model->behaviors()->get('Utils.Stateable')->config('states'));
 
         $_list = [
             0 => 'concept',

--- a/tests/TestCase/Model/Behavior/StateableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/StateableBehaviorTest.php
@@ -68,7 +68,7 @@ class StateableBehaviorTest extends TestCase
             'active' => 1,
             'deleted' => -1,
         ];
-
+        $this->Model->addBehavior('Utils.Stateable');
         $this->assertEquals($_list, $this->Model->behaviors()->get('Utils.Stateable')->config('states'));
 
         $_list = [

--- a/tests/TestCase/Model/Behavior/UploadableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UploadableBehaviorTest.php
@@ -41,9 +41,10 @@ class UploadableBehaviorTest extends TestCase
 
         $connection = ConnectionManager::get('test');
 
-        $this->Articles = $this->getMock('Cake\ORM\Table', ['_mkdir', '_moveUploadedFile'], [
-            ['table' => 'articles', 'connection' => $connection]
-        ]);
+        $this->Articles = $this->getMockBuilder('Cake\ORM\Table')
+            ->setConstructorArgs([['table' => 'articles', 'connection' => $connection]])
+            ->setMethods(['_mkdir', '_moveUploadedFile'])
+            ->getMock();
     }
 
     /**
@@ -170,11 +171,12 @@ class UploadableBehaviorTest extends TestCase
     {
         $connection = ConnectionManager::get('test');
 
-        $table = $this->getMock('Cake\ORM\Table', ['_nonExistingMethodElseTheMockWillMockAllMethods'], [
-            ['table' => 'articles', 'connection' => $connection]
-        ]);
+        $table = $this->getMockBuilder('Cake\ORM\Table')
+            ->setConstructorArgs([['table' => 'articles', 'connection' => $connection]])
+            ->setMethods(['_nonExistingMethodElseTheMockWillMockAllMethods'])
+            ->getMock();
 
-        $table->alias("Articles");
+        $table->setAlias("Articles");
 
         $behaviorOptions = [
             'file' => [
@@ -191,7 +193,10 @@ class UploadableBehaviorTest extends TestCase
 
         $mocks = ['_mkdir', '_MoveUploadedFile'];
 
-        $behaviorMock = $this->getMock('\Utils\Model\Behavior\UploadableBehavior', $mocks, [$table, $behaviorOptions]);
+        $behaviorMock = $this->getMockBuilder('\Utils\Model\Behavior\UploadableBehavior')
+            ->setConstructorArgs([$table, $behaviorOptions])
+            ->setMethods($mocks)
+            ->getMock();
 
         $behaviorMock->expects($this->any())
             ->method('_mkdir')

--- a/tests/TestCase/Model/Behavior/UploadableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UploadableBehaviorTest.php
@@ -202,7 +202,6 @@ class UploadableBehaviorTest extends TestCase
 
         $table->behaviors()->set('Uploadable', $behaviorMock);
 
-
         $data = [
             'id' => 3,
             'user_id' => 3,

--- a/tests/TestCase/Model/Behavior/UploadableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UploadableBehaviorTest.php
@@ -28,7 +28,7 @@ class UploadableBehaviorTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['plugin.utils.articles'];
+    public $fixtures = ['plugin.Utils.Articles'];
 
     /**
      * setUp method

--- a/tests/TestCase/Model/Behavior/WhoDidItBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/WhoDidItBehaviorTest.php
@@ -69,15 +69,15 @@ class WhoDidItBehaviorTest extends TestCase
     {
         $behavior = $this->Model->behaviors()->get('WhoDidIt');
 
-        $behavior->config('fields', ['id', 'email']);
+        $behavior->setConfig('fields', ['id', 'email']);
 
         $data = $this->Model->get(1);
 
         $this->assertEquals(2, count($data->createdBy->toArray()));
         $this->assertEquals(2, count($data->modifiedBy->toArray()));
 
-        $behavior->config('fields', null);
-        $behavior->config('fields', []);
+        $behavior->setConfig('fields', null);
+        $behavior->setConfig('fields', []);
     }
 
     /**
@@ -88,14 +88,14 @@ class WhoDidItBehaviorTest extends TestCase
     {
         $behavior = $this->Model->behaviors()->get('WhoDidIt');
 
-        $behavior->config('modified_by', false);
+        $behavior->setConfig('modified_by', false);
 
         $data = $this->Model->get(1);
 
         $this->assertEquals(8, count($data->createdBy->toArray()));
         $this->assertNull($data->modifiedBy);
 
-        $behavior->config('modified_by', 'modified_by');
+        $behavior->setConfig('modified_by', 'modified_by');
     }
 
     /**

--- a/tests/TestCase/Model/Behavior/WhoDidItBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/WhoDidItBehaviorTest.php
@@ -29,8 +29,8 @@ class WhoDidItBehaviorTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.utils.articles',
-        'plugin.utils.users'
+        'plugin.Utils.Articles',
+        'plugin.Utils.Users',
     ];
 
     /**

--- a/tests/TestCase/View/Helper/MenuHelperTest.php
+++ b/tests/TestCase/View/Helper/MenuHelperTest.php
@@ -55,5 +55,6 @@ class MenuHelperTest extends TestCase
      */
     public function testInitialization()
     {
+        $this->markTestIncomplete();
     }
 }

--- a/tests/TestCase/View/Helper/SearchHelperTest.php
+++ b/tests/TestCase/View/Helper/SearchHelperTest.php
@@ -79,11 +79,10 @@ class SearchHelperTest extends TestCase
 
         parent::tearDown();
     }
-    
+
     public function testFilterForm()
     {
         $result = $this->Search->filterForm($this->data);
-        
         $this->assertContains('<form method="get" accept-charset="utf-8" action="/">', $result);
         $this->assertContains('<input type="text" name="title" placeholder="title" id="title"/>', $result);
         $this->assertContains('<select name="category" placeholder="category" id="category">', $result);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -68,7 +68,7 @@ Configure::write('App', [
     ]
 ]);
 
-Cache::config([
+Cache::setConfig([
     '_cake_core_' => [
         'engine' => 'File',
         'prefix' => 'cake_core_',
@@ -87,7 +87,7 @@ if (!getenv('db_class')) {
     putenv('db_dsn=sqlite::memory:');
 }
 
-ConnectionManager::config('test', [
+ConnectionManager::setConfig('test', [
     'className' => 'Cake\Database\Connection',
     'driver' => getenv('db_class'),
     'dsn' => getenv('db_dsn'),
@@ -101,7 +101,7 @@ Configure::write('Session', [
     'defaults' => 'php'
 ]);
 
-Log::config([
+Log::setConfig([
     'debug' => [
         'engine' => 'Cake\Log\Engine\FileLog',
         'levels' => ['notice', 'info', 'debug'],

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -16,6 +16,7 @@ use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Datasource\ConnectionManager;
+use Cake\I18n\Time;
 use Cake\Log\Log;
 use Cake\Routing\DispatcherFactory;
 
@@ -114,9 +115,9 @@ Log::setConfig([
     ]
 ]);
 
-Plugin::load('Utils', ['path' => ROOT, 'bootstrap' => true, 'routes' => true]);
+//Plugin::load('Utils', ['path' => ROOT, 'bootstrap' => true, 'routes' => true]);
 
-Carbon\Carbon::setTestNow(Carbon\Carbon::now());
+Time::setTestNow();
 
 DispatcherFactory::add('Routing');
 DispatcherFactory::add('ControllerFactory');


### PR DESCRIPTION
Replace calls to deprecated `config` by `getConfig`.
Allow `WhoDidItBehavior::beforeFind` to construct associations when behavior's 'contain' is `false` but 'CreatedBy' or 'ModifiedBy' are set manually in a specific query's 'contain'.